### PR TITLE
fix: use Go-side time.Sleep in KillSession grace period

### DIFF
--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 )
 
 // Runner handles tmux session operations
@@ -200,8 +201,9 @@ func (r *Runner) KillSession() error {
 		cmd.Run() // Ignore errors - pane might not have a process
 	}
 
-	// Wait briefly for processes to terminate
-	exec.Command("tmux", "send-keys", "-t", r.sessionName, "sleep 0.5", "C-m").Run()
+	// Wait in the Go process so the grace period is deterministic.
+	// (send-keys "sleep 0.5" runs inside a pane shell and does not block KillSession.)
+	time.Sleep(500 * time.Millisecond)
 
 	// Force kill any remaining processes with C-c again
 	for _, paneID := range paneIDs {


### PR DESCRIPTION
## Summary
Replace the non-blocking tmux `send-keys "sleep 0.5"` grace period in `KillSession` with `time.Sleep` in the Go process so shutdown timing is deterministic.

## Test plan
- [x] `go test ./internal/tmux/`
- [ ] CI green

Fixes #29