### PR TITLE
refactor: use config.WindowConfig/PaneConfig in tmux package

### DIFF
--- a/cmd/devlog/main.go
+++ b/cmd/devlog/main.go
@@ -254,29 +254,13 @@ func cmdUp(cfg *config.Config, args []string) error {
 		fmt.Fprintf(os.Stderr, "Warning: failed to cleanup old runs: %v\n", err)
 	}
 
-	// Convert config windows to tmux windows
-	windows := make([]tmux.WindowConfig, len(cfg.Tmux.Windows))
-	for i, w := range cfg.Tmux.Windows {
-		panes := make([]tmux.PaneConfig, len(w.Panes))
-		for j, p := range w.Panes {
-			panes[j] = tmux.PaneConfig{
-				Cmd: p.Cmd,
-				Log: p.Log,
-			}
-		}
-		windows[i] = tmux.WindowConfig{
-			Name:  w.Name,
-			Panes: panes,
-		}
-	}
-
 	// Create the tmux session
 	logsDir := cfg.ResolveLogsDir()
-	if err := runner.CreateSession(logsDir, windows); err != nil {
+	if err := runner.CreateSession(logsDir, cfg.Tmux.Windows); err != nil {
 		return fmt.Errorf("failed to create tmux session: %w", err)
 	}
 
-	fmt.Printf("Created tmux session '%s' with %d window(s)\n", cfg.Tmux.Session, len(windows))
+	fmt.Printf("Created tmux session '%s' with %d window(s)\n", cfg.Tmux.Session, len(cfg.Tmux.Windows))
 
 	// Set up browser logging wrapper if configured
 	if len(cfg.Browser.URLs) > 0 && cfg.Browser.File != "" {

--- a/internal/tmux/integration_test.go
+++ b/internal/tmux/integration_test.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/jellydn/devlog/internal/config"
 )
 
 // skipIfNoTmux skips the test if tmux is not available
@@ -44,10 +46,10 @@ func TestTmuxIntegration_CreateSession(t *testing.T) {
 	}()
 
 	// Test session creation
-	windows := []WindowConfig{
+	windows := []config.WindowConfig{
 		{
 			Name: "test",
-			Panes: []PaneConfig{
+			Panes: []config.PaneConfig{
 				{Cmd: "echo 'test'", Log: "test.log"},
 			},
 		},
@@ -87,24 +89,24 @@ func TestTmuxIntegration_MultipleWindowsAndPanes(t *testing.T) {
 	}()
 
 	tmpDir := t.TempDir()
-	windows := []WindowConfig{
+	windows := []config.WindowConfig{
 		{
 			Name: "main",
-			Panes: []PaneConfig{
+			Panes: []config.PaneConfig{
 				{Cmd: "echo 'pane 1'", Log: "pane1.log"},
 				{Cmd: "echo 'pane 2'", Log: "pane2.log"},
 			},
 		},
 		{
 			Name: "secondary",
-			Panes: []PaneConfig{
+			Panes: []config.PaneConfig{
 				{Cmd: "echo 'pane 3'", Log: "pane3.log"},
 				{Cmd: "echo 'pane 4'", Log: "pane4.log"},
 			},
 		},
 		{
 			Name: "tertiary",
-			Panes: []PaneConfig{
+			Panes: []config.PaneConfig{
 				{Cmd: "echo 'pane 5'", Log: "pane5.log"},
 			},
 		},
@@ -175,10 +177,10 @@ func TestTmuxIntegration_LogCapture(t *testing.T) {
 
 	tmpDir := t.TempDir()
 	testMessage := "integration-test-message"
-	windows := []WindowConfig{
+	windows := []config.WindowConfig{
 		{
 			Name: "test",
-			Panes: []PaneConfig{
+			Panes: []config.PaneConfig{
 				{Cmd: fmt.Sprintf("echo %s", testMessage), Log: "capture.log"},
 			},
 		},
@@ -217,10 +219,10 @@ func TestTmuxIntegration_SessionLifecycle(t *testing.T) {
 	}
 
 	tmpDir := t.TempDir()
-	windows := []WindowConfig{
+	windows := []config.WindowConfig{
 		{
 			Name: "test",
-			Panes: []PaneConfig{
+			Panes: []config.PaneConfig{
 				{Cmd: "echo test", Log: "test.log"},
 			},
 		},
@@ -277,10 +279,10 @@ func TestTmuxIntegration_DuplicateSession(t *testing.T) {
 	}()
 
 	tmpDir := t.TempDir()
-	windows := []WindowConfig{
+	windows := []config.WindowConfig{
 		{
 			Name: "test",
-			Panes: []PaneConfig{
+			Panes: []config.PaneConfig{
 				{Cmd: "echo test", Log: "test.log"},
 			},
 		},
@@ -330,10 +332,10 @@ func TestTmuxIntegration_SpecialCharactersInPaths(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			windows := []WindowConfig{
+			windows := []config.WindowConfig{
 				{
 					Name: "test",
-					Panes: []PaneConfig{
+					Panes: []config.PaneConfig{
 						{Cmd: "echo test", Log: tc.logFile},
 					},
 				},
@@ -378,10 +380,10 @@ func TestTmuxIntegration_EmptyLogFile(t *testing.T) {
 	}()
 
 	tmpDir := t.TempDir()
-	windows := []WindowConfig{
+	windows := []config.WindowConfig{
 		{
 			Name: "test",
-			Panes: []PaneConfig{
+			Panes: []config.PaneConfig{
 				{Cmd: "echo 'logged'", Log: "with-log.log"},
 				{Cmd: "echo 'not logged'", Log: ""}, // No log file
 			},
@@ -421,10 +423,10 @@ func TestTmuxIntegration_GetLogsDir(t *testing.T) {
 	}()
 
 	tmpDir := t.TempDir()
-	windows := []WindowConfig{
+	windows := []config.WindowConfig{
 		{
 			Name: "test",
-			Panes: []PaneConfig{
+			Panes: []config.PaneConfig{
 				{Cmd: "echo test", Log: "test.log"},
 			},
 		},
@@ -467,10 +469,10 @@ func TestTmuxIntegration_MultiplePanesSameLogFile(t *testing.T) {
 
 	tmpDir := t.TempDir()
 	sharedLog := "shared.log"
-	windows := []WindowConfig{
+	windows := []config.WindowConfig{
 		{
 			Name: "test",
-			Panes: []PaneConfig{
+			Panes: []config.PaneConfig{
 				{Cmd: "echo 'message-from-pane-1'", Log: sharedLog},
 				{Cmd: "echo 'message-from-pane-2'", Log: sharedLog},
 			},
@@ -516,10 +518,10 @@ func TestTmuxIntegration_LongSessionName(t *testing.T) {
 	}()
 
 	tmpDir := t.TempDir()
-	windows := []WindowConfig{
+	windows := []config.WindowConfig{
 		{
 			Name: "test",
-			Panes: []PaneConfig{
+			Panes: []config.PaneConfig{
 				{Cmd: "echo test", Log: "test.log"},
 			},
 		},
@@ -557,10 +559,10 @@ func TestTmuxIntegration_PaneCommands(t *testing.T) {
 	}()
 
 	tmpDir := t.TempDir()
-	windows := []WindowConfig{
+	windows := []config.WindowConfig{
 		{
 			Name: "test",
-			Panes: []PaneConfig{
+			Panes: []config.PaneConfig{
 				{Cmd: "echo hello", Log: "echo.log"},
 				{Cmd: "date", Log: "date.log"},
 				{Cmd: "pwd", Log: "pwd.log"},
@@ -604,10 +606,10 @@ func TestTmuxIntegration_PosixCommandSyntax(t *testing.T) {
 
 	tmpDir := t.TempDir()
 	logFile := "posix.log"
-	windows := []WindowConfig{
+	windows := []config.WindowConfig{
 		{
 			Name: "test",
-			Panes: []PaneConfig{
+			Panes: []config.PaneConfig{
 				{Cmd: "(echo posix-syntax-works) | cat", Log: logFile},
 			},
 		},

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -6,6 +6,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"github.com/jellydn/devlog/internal/config"
 )
 
 // Runner handles tmux session operations
@@ -28,7 +30,7 @@ func (r *Runner) SessionExists() bool {
 }
 
 // CreateSession creates a new tmux session with the given windows and panes
-func (r *Runner) CreateSession(logsDir string, windows []WindowConfig) error {
+func (r *Runner) CreateSession(logsDir string, windows []config.WindowConfig) error {
 	if r.SessionExists() {
 		return fmt.Errorf("tmux session '%s' already exists", r.sessionName)
 	}
@@ -86,7 +88,7 @@ func (r *Runner) CreateSession(logsDir string, windows []WindowConfig) error {
 	return nil
 }
 
-func ensurePaneLogFiles(logsDir string, windows []WindowConfig) error {
+func ensurePaneLogFiles(logsDir string, windows []config.WindowConfig) error {
 	seen := make(map[string]struct{})
 	for _, window := range windows {
 		for _, pane := range window.Panes {
@@ -118,7 +120,7 @@ func ensurePaneLogFiles(logsDir string, windows []WindowConfig) error {
 }
 
 // createWindow creates a new window with its panes
-func (r *Runner) createWindow(windowIndex int, window WindowConfig, logsDir string) error {
+func (r *Runner) createWindow(windowIndex int, window config.WindowConfig, logsDir string) error {
 	cmd := exec.Command("tmux", "new-window", "-t", r.sessionName, "-n", window.Name)
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("failed to create window: %w", err)
@@ -342,18 +344,6 @@ type PaneInfo struct {
 	ID      string
 	Index   int
 	Command string
-}
-
-// WindowConfig represents a tmux window configuration
-type WindowConfig struct {
-	Name  string
-	Panes []PaneConfig
-}
-
-// PaneConfig represents a tmux pane configuration
-type PaneConfig struct {
-	Cmd string
-	Log string
 }
 
 // CheckVersion returns the tmux version string or an error if tmux is not installed

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/jellydn/devlog/internal/config"
 )
 
 func TestRunner_SessionExists(t *testing.T) {
@@ -50,10 +52,10 @@ func TestRunner_CreateSession_AlreadyExists(t *testing.T) {
 	defer exec.Command("tmux", "kill-session", "-t", "test-duplicate-session").Run()
 
 	// Try to create again - should fail
-	err := runner.CreateSession("/tmp/testlogs", []WindowConfig{
+	err := runner.CreateSession("/tmp/testlogs", []config.WindowConfig{
 		{
 			Name: "main",
-			Panes: []PaneConfig{
+			Panes: []config.PaneConfig{
 				{Cmd: "echo test", Log: "test.log"},
 			},
 		},
@@ -97,17 +99,17 @@ func TestRunner_CreateAndKillSession(t *testing.T) {
 	exec.Command("tmux", "kill-session", "-t", sessionName).Run()
 
 	logsDir := t.TempDir()
-	windows := []WindowConfig{
+	windows := []config.WindowConfig{
 		{
 			Name: "main",
-			Panes: []PaneConfig{
+			Panes: []config.PaneConfig{
 				{Cmd: "echo 'pane 1'", Log: "pane1.log"},
 				{Cmd: "echo 'pane 2'", Log: "pane2.log"},
 			},
 		},
 		{
 			Name: "secondary",
-			Panes: []PaneConfig{
+			Panes: []config.PaneConfig{
 				{Cmd: "echo 'pane 3'", Log: "pane3.log"},
 			},
 		},
@@ -193,7 +195,7 @@ func TestRunner_CreateSession_NoWindows(t *testing.T) {
 	runner := NewRunner("test-no-windows")
 	logsDir := t.TempDir()
 
-	err := runner.CreateSession(logsDir, []WindowConfig{})
+	err := runner.CreateSession(logsDir, []config.WindowConfig{})
 	if err == nil {
 		t.Error("CreateSession() expected error for empty windows, got nil")
 	}
@@ -215,10 +217,10 @@ func TestRunner_CreateSession_CreatesLogsDir(t *testing.T) {
 	exec.Command("tmux", "kill-session", "-t", sessionName).Run()
 
 	logsDir := t.TempDir() + "/nested/logs/dir"
-	windows := []WindowConfig{
+	windows := []config.WindowConfig{
 		{
 			Name: "main",
-			Panes: []PaneConfig{
+			Panes: []config.PaneConfig{
 				{Cmd: "echo test", Log: "test.log"},
 			},
 		},
@@ -257,10 +259,10 @@ func TestCheckVersion(t *testing.T) {
 
 func TestEnsurePaneLogFiles(t *testing.T) {
 	logsDir := t.TempDir()
-	windows := []WindowConfig{
+	windows := []config.WindowConfig{
 		{
 			Name: "main",
-			Panes: []PaneConfig{
+			Panes: []config.PaneConfig{
 				{Cmd: "echo test", Log: "web.log"},
 				{Cmd: "echo test", Log: "nested/api.log"},
 				{Cmd: "echo test", Log: "nested/api.log"},


### PR DESCRIPTION
## Summary
Remove duplicated `WindowConfig` / `PaneConfig` from `internal/tmux` and accept `config` types directly in `CreateSession`. Drops the manual mapping in `cmdUp`.

## Test plan
- [x] `go test ./...`
- [ ] CI green

Fixes #28