### PR TITLE
feat: add Windows .bat wrapper for browser native messaging

### DIFF
--- a/cmd/devlog/helpers.go
+++ b/cmd/devlog/helpers.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/jellydn/devlog/internal/natmsg"
@@ -44,6 +45,13 @@ func ensureFileExists(path string) error {
 	return f.Close()
 }
 
+func browserHostWrapperExt() string {
+	if runtime.GOOS == "windows" {
+		return ".bat"
+	}
+	return ".sh"
+}
+
 func browserHostWrapperPath(session string) string {
 	cacheDir, err := os.UserCacheDir()
 	if err != nil {
@@ -53,7 +61,7 @@ func browserHostWrapperPath(session string) string {
 		cacheDir,
 		"devlog",
 		"wrappers",
-		fmt.Sprintf("devlog-host-wrapper-%s.sh", sanitizeSessionForFileName(session)),
+		fmt.Sprintf("devlog-host-wrapper-%s%s", sanitizeSessionForFileName(session), browserHostWrapperExt()),
 	)
 }
 
@@ -98,14 +106,12 @@ func writeBrowserHostWrapper(session string, browserLogPath string, levels []str
 		return err
 	}
 
-	// Build script with proper shell escaping using positional parameters
-	// Use "$@" to safely pass arguments without re-parsing by the shell
-	var scriptArgs []string
-	scriptArgs = append(scriptArgs, shellQuote(hostPath), shellQuote(absLogPath))
-	for _, level := range levels {
-		scriptArgs = append(scriptArgs, shellQuote(level))
+	var script string
+	if runtime.GOOS == "windows" {
+		script = generateBatchScript(hostPath, absLogPath, levels)
+	} else {
+		script = generateShellScript(hostPath, absLogPath, levels)
 	}
-	script := fmt.Sprintf("#!/bin/sh\nexec %s\n", strings.Join(scriptArgs, " "))
 	if err := os.WriteFile(wrapperPath, []byte(script), 0755); err != nil {
 		return err
 	}
@@ -115,6 +121,26 @@ func writeBrowserHostWrapper(session string, browserLogPath string, levels []str
 	}
 
 	return nil
+}
+
+func generateShellScript(hostPath, absLogPath string, levels []string) string {
+	// Build script with proper shell escaping. exec replaces the shell with the host.
+	var scriptArgs []string
+	scriptArgs = append(scriptArgs, shellQuote(hostPath), shellQuote(absLogPath))
+	for _, level := range levels {
+		scriptArgs = append(scriptArgs, shellQuote(level))
+	}
+	return fmt.Sprintf("#!/bin/sh\nexec %s\n", strings.Join(scriptArgs, " "))
+}
+
+func generateBatchScript(hostPath, absLogPath string, levels []string) string {
+	// Native messaging on Windows can invoke a .bat host wrapper.
+	var scriptArgs []string
+	scriptArgs = append(scriptArgs, batchQuote(hostPath), batchQuote(absLogPath))
+	for _, level := range levels {
+		scriptArgs = append(scriptArgs, batchQuote(level))
+	}
+	return "@echo off\r\n" + strings.Join(scriptArgs, " ") + "\r\n"
 }
 
 func restoreBrowserHostWrapper(session string) {
@@ -133,7 +159,7 @@ func restoreBrowserHostWrapper(session string) {
 }
 
 // shellQuote returns a shell-escaped version of the string using single quotes.
-// Any single quotes in the input are escaped as '\”' to safely include them.
+// Any single quotes in the input are escaped as '\” to safely include them.
 func shellQuote(s string) string {
 	if s == "" {
 		return "''"
@@ -141,4 +167,8 @@ func shellQuote(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
 }
 
-// openInFileManager opens the given path in the system file manager
+// batchQuote returns a Windows batch-escaped argument using double quotes.
+// Embedded double quotes are escaped by doubling them.
+func batchQuote(s string) string {
+	return `"` + strings.ReplaceAll(s, `"`, `""`) + `"`
+}

--- a/cmd/devlog/helpers_test.go
+++ b/cmd/devlog/helpers_test.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestSanitizeSessionForFileName(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"", "default"},
+		{"my-app", "my-app"},
+		{"My App!", "My-App"},
+		{"---", "default"},
+		{"a/b:c", "a-b-c"},
+	}
+	for _, tt := range tests {
+		got := sanitizeSessionForFileName(tt.in)
+		if got != tt.want {
+			t.Errorf("sanitizeSessionForFileName(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestBrowserHostWrapperPath_Extension(t *testing.T) {
+	path := browserHostWrapperPath("demo")
+	wantExt := ".sh"
+	if runtime.GOOS == "windows" {
+		wantExt = ".bat"
+	}
+	if !strings.HasSuffix(path, "devlog-host-wrapper-demo"+wantExt) {
+		t.Errorf("browserHostWrapperPath() = %q, want suffix devlog-host-wrapper-demo%s", path, wantExt)
+	}
+	if !strings.Contains(path, filepath.Join("devlog", "wrappers")) {
+		t.Errorf("browserHostWrapperPath() = %q, want wrappers under devlog cache", path)
+	}
+}
+
+func TestGenerateShellScript(t *testing.T) {
+	got := generateShellScript(`/usr/local/bin/devlog-host`, `/tmp/logs/browser.log`, []string{"error", "warn"})
+	want := "#!/bin/sh\nexec '/usr/local/bin/devlog-host' '/tmp/logs/browser.log' 'error' 'warn'\n"
+	if got != want {
+		t.Errorf("generateShellScript() = %q, want %q", got, want)
+	}
+}
+
+func TestGenerateShellScript_EscapesSingleQuotes(t *testing.T) {
+	got := generateShellScript(`/tmp/o'reilly/host`, `/tmp/log`, nil)
+	if !strings.Contains(got, `'/tmp/o'\''reilly/host'`) {
+		t.Errorf("generateShellScript() did not escape single quotes: %q", got)
+	}
+}
+
+func TestGenerateBatchScript(t *testing.T) {
+	got := generateBatchScript(`C:\Tools\devlog-host.exe`, `C:\Logs\browser.log`, []string{"error", "warn"})
+	want := "@echo off\r\n" +
+		`"C:\Tools\devlog-host.exe" "C:\Logs\browser.log" "error" "warn"` +
+		"\r\n"
+	if got != want {
+		t.Errorf("generateBatchScript() = %q, want %q", got, want)
+	}
+}
+
+func TestGenerateBatchScript_EscapesDoubleQuotes(t *testing.T) {
+	got := generateBatchScript(`C:\Tools\dev"log-host.exe`, `C:\Logs\a.log`, nil)
+	if !strings.Contains(got, `"C:\Tools\dev""log-host.exe"`) {
+		t.Errorf("generateBatchScript() did not escape double quotes: %q", got)
+	}
+}
+
+func TestShellQuote(t *testing.T) {
+	if shellQuote("") != "''" {
+		t.Errorf("shellQuote empty = %q", shellQuote(""))
+	}
+	if shellQuote("plain") != "'plain'" {
+		t.Errorf("shellQuote plain = %q", shellQuote("plain"))
+	}
+}
+
+func TestBatchQuote(t *testing.T) {
+	if batchQuote(`C:\a b\x.exe`) != `"C:\a b\x.exe"` {
+		t.Errorf("batchQuote spaces = %q", batchQuote(`C:\a b\x.exe`))
+	}
+	if batchQuote(`say "hi"`) != `"say ""hi"""` {
+		t.Errorf("batchQuote quotes = %q", batchQuote(`say "hi"`))
+	}
+}


### PR DESCRIPTION
## Summary
Generate a Windows `.bat` native-messaging host wrapper (with batch quoting) while keeping the Unix shell wrapper. Adds unit tests for both generators.

Depends on #38 (CLI extract).

## Test plan
- [x] `go test ./cmd/devlog/ -run 'TestGenerate|TestBatch|TestShell|TestBrowserHost'`
- [x] `go test ./...`
- [ ] CI green

Fixes #10