### PR TITLE
refactor: return CleanupResult instead of printing from config

### DIFF
--- a/cmd/devlog/cmd_up.go
+++ b/cmd/devlog/cmd_up.go
@@ -22,8 +22,15 @@ func cmdUp(cfg *config.Config, args []string) error {
 	}
 
 	// Clean up old log runs if retention policy is configured
-	if err := cfg.CleanupOldRuns(false); err != nil {
+	if result, err := cfg.CleanupOldRuns(false); err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: failed to cleanup old runs: %v\n", err)
+	} else if result != nil {
+		for _, dir := range result.Removed {
+			fmt.Printf("Removed old log directory: %s\n", dir)
+		}
+		for dir, remErr := range result.Failed {
+			fmt.Fprintf(os.Stderr, "Warning: failed to remove %s: %v\n", dir, remErr)
+		}
 	}
 
 	// Create the tmux session

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -149,24 +149,37 @@ func interpolateEnvVars(input string) string {
 	})
 }
 
-// CleanupOldRuns removes old log directories based on retention policy
-func (c *Config) CleanupOldRuns(dryRun bool) error {
+// CleanupResult describes directories selected for removal by CleanupOldRuns.
+type CleanupResult struct {
+	// Removed lists directories that were removed (or would be removed in dry-run).
+	Removed []string
+	// Failed maps directory paths that could not be removed to the error.
+	Failed map[string]error
+}
+
+// CleanupOldRuns removes old log directories based on retention policy.
+// It does not print; callers format CleanupResult for the user.
+func (c *Config) CleanupOldRuns(dryRun bool) (*CleanupResult, error) {
+	result := &CleanupResult{
+		Failed: make(map[string]error),
+	}
+
 	// Only cleanup for timestamped mode
 	if c.RunMode != "timestamped" {
-		return nil
+		return result, nil
 	}
 
 	// Skip if no retention policy is set
 	if c.MaxRuns == 0 && c.RetentionDays == 0 {
-		return nil
+		return result, nil
 	}
 
 	entries, err := os.ReadDir(c.LogsDir)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil // Nothing to clean up
+			return result, nil // Nothing to clean up
 		}
-		return fmt.Errorf("failed to read logs directory: %w", err)
+		return result, fmt.Errorf("failed to read logs directory: %w", err)
 	}
 
 	// Collect directories with their info
@@ -212,19 +225,19 @@ func (c *Config) CleanupOldRuns(dryRun bool) error {
 		}
 	}
 
-	// Remove directories
+	// Remove directories (or record dry-run candidates)
 	for name := range toRemove {
 		dirPath := filepath.Join(c.LogsDir, name)
 		if dryRun {
-			fmt.Printf("[DRY RUN] Would remove: %s\n", dirPath)
-		} else {
-			if err := os.RemoveAll(dirPath); err != nil {
-				fmt.Fprintf(os.Stderr, "Warning: failed to remove %s: %v\n", dirPath, err)
-			} else {
-				fmt.Printf("Removed old log directory: %s\n", dirPath)
-			}
+			result.Removed = append(result.Removed, dirPath)
+			continue
 		}
+		if err := os.RemoveAll(dirPath); err != nil {
+			result.Failed[dirPath] = err
+			continue
+		}
+		result.Removed = append(result.Removed, dirPath)
 	}
 
-	return nil
+	return result, nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -433,8 +433,15 @@ func TestCleanupOldRuns_MaxRuns(t *testing.T) {
 		MaxRuns: 3,
 	}
 
-	if err := cfg.CleanupOldRuns(false); err != nil {
+	result, err := cfg.CleanupOldRuns(false)
+	if err != nil {
 		t.Fatalf("CleanupOldRuns() failed: %v", err)
+	}
+	if len(result.Removed) != 2 {
+		t.Errorf("Removed = %v, want 2", result.Removed)
+	}
+	if len(result.Failed) != 0 {
+		t.Errorf("Failed = %v, want empty", result.Failed)
 	}
 
 	// Check that only 3 directories remain
@@ -484,9 +491,11 @@ func TestCleanupOldRuns_RetentionDays(t *testing.T) {
 		RetentionDays: 30,
 	}
 
-	if err := cfg.CleanupOldRuns(false); err != nil {
+	result, err := cfg.CleanupOldRuns(false)
+	if err != nil {
 		t.Fatalf("CleanupOldRuns() failed: %v", err)
 	}
+	_ = result
 
 	// Check that old directory is removed
 	if _, err := os.Stat(oldDir); !os.IsNotExist(err) {
@@ -520,8 +529,12 @@ func TestCleanupOldRuns_DryRun(t *testing.T) {
 		MaxRuns: 3,
 	}
 
-	if err := cfg.CleanupOldRuns(true); err != nil {
+	result, err := cfg.CleanupOldRuns(true)
+	if err != nil {
 		t.Fatalf("CleanupOldRuns() failed: %v", err)
+	}
+	if len(result.Removed) != 2 {
+		t.Errorf("DryRun Removed = %v, want 2 candidates", result.Removed)
 	}
 
 	// Check that all 5 directories still exist (dry run)
@@ -564,9 +577,11 @@ func TestCleanupOldRuns_NoPolicy(t *testing.T) {
 		RetentionDays: 0,
 	}
 
-	if err := cfg.CleanupOldRuns(false); err != nil {
+	result, err := cfg.CleanupOldRuns(false)
+	if err != nil {
 		t.Fatalf("CleanupOldRuns() failed: %v", err)
 	}
+	_ = result
 
 	// Check that all directories still exist (no policy)
 	entries, err := os.ReadDir(logsDir)
@@ -597,7 +612,9 @@ func TestCleanupOldRuns_OverwriteMode(t *testing.T) {
 	}
 
 	// Should return nil without error for overwrite mode
-	if err := cfg.CleanupOldRuns(false); err != nil {
+	result, err := cfg.CleanupOldRuns(false)
+	if err != nil {
 		t.Fatalf("CleanupOldRuns() failed: %v", err)
 	}
+	_ = result
 }


### PR DESCRIPTION
## Summary
Return `CleanupResult` from `Config.CleanupOldRuns` instead of printing from the library package. `cmdUp` formats user-facing output.

## Test plan
- [x] `go test ./internal/config/ -run Cleanup`
- [x] `go test ./...`
- [ ] CI green

Fixes #41