### PR TITLE
security: centralize shell escaping in internal/shellescape

### DIFF
--- a/cmd/devlog/helpers.go
+++ b/cmd/devlog/helpers.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/jellydn/devlog/internal/natmsg"
+	"github.com/jellydn/devlog/internal/shellescape"
 )
 
 func findConfigFile() string {
@@ -126,9 +127,9 @@ func writeBrowserHostWrapper(session string, browserLogPath string, levels []str
 func generateShellScript(hostPath, absLogPath string, levels []string) string {
 	// Build script with proper shell escaping. exec replaces the shell with the host.
 	var scriptArgs []string
-	scriptArgs = append(scriptArgs, shellQuote(hostPath), shellQuote(absLogPath))
+	scriptArgs = append(scriptArgs, shellescape.Quote(hostPath), shellescape.Quote(absLogPath))
 	for _, level := range levels {
-		scriptArgs = append(scriptArgs, shellQuote(level))
+		scriptArgs = append(scriptArgs, shellescape.Quote(level))
 	}
 	return fmt.Sprintf("#!/bin/sh\nexec %s\n", strings.Join(scriptArgs, " "))
 }
@@ -156,15 +157,6 @@ func restoreBrowserHostWrapper(session string) {
 	}
 
 	os.Remove(wrapperPath)
-}
-
-// shellQuote returns a shell-escaped version of the string using single quotes.
-// Any single quotes in the input are escaped as '\” to safely include them.
-func shellQuote(s string) string {
-	if s == "" {
-		return "''"
-	}
-	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
 }
 
 // batchQuote returns a Windows batch-escaped argument using double quotes.

--- a/cmd/devlog/helpers_test.go
+++ b/cmd/devlog/helpers_test.go
@@ -72,15 +72,6 @@ func TestGenerateBatchScript_EscapesDoubleQuotes(t *testing.T) {
 	}
 }
 
-func TestShellQuote(t *testing.T) {
-	if shellQuote("") != "''" {
-		t.Errorf("shellQuote empty = %q", shellQuote(""))
-	}
-	if shellQuote("plain") != "'plain'" {
-		t.Errorf("shellQuote plain = %q", shellQuote("plain"))
-	}
-}
-
 func TestBatchQuote(t *testing.T) {
 	if batchQuote(`C:\a b\x.exe`) != `"C:\a b\x.exe"` {
 		t.Errorf("batchQuote spaces = %q", batchQuote(`C:\a b\x.exe`))

--- a/internal/shellescape/shellescape.go
+++ b/internal/shellescape/shellescape.go
@@ -1,0 +1,16 @@
+// Package shellescape provides POSIX shell single-quote escaping helpers.
+package shellescape
+
+import "strings"
+
+// Quote returns a shell-safe single-quoted representation of s suitable for
+// interpolation into a POSIX shell command line (e.g. sh -lc).
+// Empty strings become ” so they remain a single argument.
+func Quote(s string) string {
+	if s == "" {
+		return "''"
+	}
+	// Wrap in single quotes; escape any embedded ' as '\'' (end quote, escaped
+	// literal quote, reopen quote).
+	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
+}

--- a/internal/shellescape/shellescape_test.go
+++ b/internal/shellescape/shellescape_test.go
@@ -1,0 +1,75 @@
+package shellescape
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+	"testing/quick"
+)
+
+func TestQuote(t *testing.T) {
+	inputs := []string{
+		"",
+		"simple",
+		"a'b",
+		"; rm -rf $HOME; '",
+		"$HOME",
+		"hello world",
+	}
+	for _, in := range inputs {
+		got := Quote(in)
+		var want string
+		if in == "" {
+			want = "''"
+		} else {
+			want = "'" + strings.ReplaceAll(in, "'", "'\\''") + "'"
+		}
+		if got != want {
+			t.Errorf("Quote(%q) = %q, want %q", in, got, want)
+		}
+		if !strings.HasPrefix(got, "'") || !strings.HasSuffix(got, "'") {
+			t.Errorf("Quote(%q) = %q, should be single-quoted", in, got)
+		}
+	}
+}
+
+func TestQuote_InjectionCannotBreakOut(t *testing.T) {
+	// A hostile cmd that would run rm if unquoted or poorly escaped.
+	hostile := `; rm -rf /tmp/devlog-shellescape-should-not-exist; echo pwned; '`
+	quoted := Quote(hostile)
+
+	// When used as the argument to printf via sh -c, the shell should treat
+	// the whole string as data, not execute rm.
+	cmd := exec.Command("sh", "-c", "printf %s "+quoted)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("sh failed: %v output=%q", err, out)
+	}
+	if string(out) != hostile {
+		t.Errorf("round-trip = %q, want original %q", out, hostile)
+	}
+}
+
+func TestQuote_RoundTripProperty(t *testing.T) {
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("sh not available")
+	}
+
+	f := func(s string) bool {
+		// Cap size to keep the property test fast.
+		if len(s) > 200 {
+			return true
+		}
+		quoted := Quote(s)
+		cmd := exec.Command("sh", "-c", "printf %s "+quoted)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Logf("sh error for %q quoted=%q: %v %s", s, quoted, err, out)
+			return false
+		}
+		return string(out) == s
+	}
+	if err := quick.Check(f, &quick.Config{MaxCount: 100}); err != nil {
+		t.Error(err)
+	}
+}

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/jellydn/devlog/internal/config"
+	"github.com/jellydn/devlog/internal/shellescape"
 )
 
 // Runner handles tmux session operations
@@ -165,8 +166,7 @@ func (r *Runner) sendCommandWithLogging(target, command, logsDir, logFile string
 		logPath := filepath.Join(logsDir, logFile)
 
 		// Quote the path to prevent command injection
-		escapedPath := "'" + strings.ReplaceAll(logPath, "'", "'\\''") + "'"
-		pipeCmd := fmt.Sprintf("cat >> %s", escapedPath)
+		pipeCmd := fmt.Sprintf("cat >> %s", shellescape.Quote(logPath))
 		cmd := exec.Command("tmux", "pipe-pane", "-t", target, "-o", pipeCmd)
 		if err := cmd.Run(); err != nil {
 			return fmt.Errorf("failed to set up pipe-pane logging: %w", err)
@@ -175,8 +175,7 @@ func (r *Runner) sendCommandWithLogging(target, command, logsDir, logFile string
 
 	// Run pane commands through POSIX sh so bash-style syntax works even when the
 	// user's interactive shell is fish/zsh.
-	escapedCommand := "'" + strings.ReplaceAll(command, "'", "'\\''") + "'"
-	shCommand := fmt.Sprintf("sh -lc %s", escapedCommand)
+	shCommand := fmt.Sprintf("sh -lc %s", shellescape.Quote(command))
 	cmd := exec.Command("tmux", "send-keys", "-t", target, shCommand, "C-m")
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("failed to send command: %w", err)


### PR DESCRIPTION
## Summary
Extract POSIX single-quote escaping into `internal/shellescape` used by tmux and the browser host wrapper. Adds injection + property tests.

## Test plan
- [x] `go test ./internal/shellescape/ ./internal/tmux/ ./cmd/devlog/`
- [ ] CI green

Fixes #42