### PR TITLE
fix: parse tmux list output with tab delimiters

### DIFF
--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -266,26 +267,19 @@ func (r *Runner) GetSessionInfo() (*SessionInfo, error) {
 		Windows: []WindowInfo{},
 	}
 
-	cmd := exec.Command("tmux", "list-windows", "-t", r.sessionName, "-F", "#{window_index}|#{window_name}|#{window_panes}")
+	// Use tabs as field separators — window/pane names can contain '|' but not tabs
+	// in tmux -F output.
+	cmd := exec.Command("tmux", "list-windows", "-t", r.sessionName, "-F", "#{window_index}\t#{window_name}\t#{window_panes}")
 	output, err := cmd.Output()
 	if err != nil {
 		return nil, fmt.Errorf("failed to list windows: %w", err)
 	}
 
-	// Parse window list (format: index|name|pane_count)
-	lines := strings.Split(string(output), "\n")
-	for _, line := range lines {
-		if line == "" {
+	for _, line := range strings.Split(string(output), "\n") {
+		window, ok := parseWindowLine(line)
+		if !ok {
 			continue
 		}
-		parts := strings.Split(line, "|")
-		if len(parts) != 3 {
-			continue
-		}
-		var window WindowInfo
-		fmt.Sscanf(parts[0], "%d", &window.Index)
-		window.Name = parts[1]
-		fmt.Sscanf(parts[2], "%d", &window.PaneCount)
 
 		panes, err := r.getWindowPanes(window.Index)
 		if err == nil {
@@ -301,30 +295,68 @@ func (r *Runner) GetSessionInfo() (*SessionInfo, error) {
 // getWindowPanes returns information about all panes in a window
 func (r *Runner) getWindowPanes(windowIndex int) ([]PaneInfo, error) {
 	windowTarget := fmt.Sprintf("%s:%d", r.sessionName, windowIndex)
-	cmd := exec.Command("tmux", "list-panes", "-t", windowTarget, "-F", "#{pane_id}|#{pane_index}|#{pane_current_command}")
+	cmd := exec.Command("tmux", "list-panes", "-t", windowTarget, "-F", "#{pane_id}\t#{pane_index}\t#{pane_current_command}")
 	output, err := cmd.Output()
 	if err != nil {
 		return nil, err
 	}
 
 	var panes []PaneInfo
-	lines := strings.Split(string(output), "\n")
-	for _, line := range lines {
-		if line == "" {
+	for _, line := range strings.Split(string(output), "\n") {
+		pane, ok := parsePaneLine(line)
+		if !ok {
 			continue
 		}
-		parts := strings.Split(line, "|")
-		if len(parts) != 3 {
-			continue
-		}
-		var pane PaneInfo
-		pane.ID = parts[0]
-		fmt.Sscanf(parts[1], "%d", &pane.Index)
-		pane.Command = parts[2]
 		panes = append(panes, pane)
 	}
 
 	return panes, nil
+}
+
+// parseWindowLine parses a tab-delimited tmux list-windows -F line:
+// index\tname\tpane_count
+func parseWindowLine(line string) (WindowInfo, bool) {
+	var window WindowInfo
+	if line == "" {
+		return window, false
+	}
+	parts := strings.Split(line, "\t")
+	if len(parts) != 3 {
+		return window, false
+	}
+	index, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return window, false
+	}
+	paneCount, err := strconv.Atoi(parts[2])
+	if err != nil {
+		return window, false
+	}
+	window.Index = index
+	window.Name = parts[1]
+	window.PaneCount = paneCount
+	return window, true
+}
+
+// parsePaneLine parses a tab-delimited tmux list-panes -F line:
+// id\tindex\tcommand
+func parsePaneLine(line string) (PaneInfo, bool) {
+	var pane PaneInfo
+	if line == "" {
+		return pane, false
+	}
+	parts := strings.Split(line, "\t")
+	if len(parts) != 3 {
+		return pane, false
+	}
+	index, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return pane, false
+	}
+	pane.ID = parts[0]
+	pane.Index = index
+	pane.Command = parts[2]
+	return pane, true
 }
 
 // SessionInfo holds information about a tmux session

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -289,3 +289,48 @@ func TestEnsurePaneLogFiles(t *testing.T) {
 		}
 	}
 }
+
+func TestParseWindowLine_NameWithPipe(t *testing.T) {
+	window, ok := parseWindowLine("2\tapi|web\t3")
+	if !ok {
+		t.Fatal("parseWindowLine returned false for valid line with | in name")
+	}
+	if window.Index != 2 {
+		t.Errorf("Index = %d, want 2", window.Index)
+	}
+	if window.Name != "api|web" {
+		t.Errorf("Name = %q, want %q", window.Name, "api|web")
+	}
+	if window.PaneCount != 3 {
+		t.Errorf("PaneCount = %d, want 3", window.PaneCount)
+	}
+}
+
+func TestParseWindowLine_Invalid(t *testing.T) {
+	if _, ok := parseWindowLine(""); ok {
+		t.Error("empty line should fail")
+	}
+	// Pipe-delimited legacy format should not parse (we use tabs now)
+	if _, ok := parseWindowLine("1|main|2"); ok {
+		t.Error("pipe-delimited line should fail with tab parser")
+	}
+	if _, ok := parseWindowLine("x\tmain\t2"); ok {
+		t.Error("non-numeric index should fail")
+	}
+}
+
+func TestParsePaneLine_CommandWithPipe(t *testing.T) {
+	pane, ok := parsePaneLine("%0\t1\tsh -c 'echo a|b'")
+	if !ok {
+		t.Fatal("parsePaneLine returned false")
+	}
+	if pane.ID != "%0" {
+		t.Errorf("ID = %q, want %%0", pane.ID)
+	}
+	if pane.Index != 1 {
+		t.Errorf("Index = %d, want 1", pane.Index)
+	}
+	if pane.Command != "sh -c 'echo a|b'" {
+		t.Errorf("Command = %q", pane.Command)
+	}
+}


### PR DESCRIPTION
## Summary
Parse tmux `list-windows` / `list-panes` with tab delimiters so names containing `|` are not dropped. Use `strconv.Atoi` and unit-test pipe-containing names.

## Test plan
- [x] `go test ./internal/tmux/`
- [ ] CI green

Fixes #44