### PR TITLE
fix: self-heal stale native messaging wrapper paths

### DIFF
--- a/cmd/devlog/browser_wrapper_test.go
+++ b/cmd/devlog/browser_wrapper_test.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/jellydn/devlog/internal/natmsg"
+)
+
+func withIsolatedHome(t *testing.T) (home string, cleanup func()) {
+	t.Helper()
+	home = t.TempDir()
+	prevHome := os.Getenv("HOME")
+	prevXDG := os.Getenv("XDG_CONFIG_HOME")
+	prevCache := os.Getenv("XDG_CACHE_HOME")
+	os.Setenv("HOME", home)
+	os.Unsetenv("XDG_CONFIG_HOME")
+	// Point cache under home so wrapper paths are isolated
+	cache := filepath.Join(home, "Library", "Caches")
+	if runtime.GOOS != "darwin" {
+		cache = filepath.Join(home, ".cache")
+		os.Setenv("XDG_CACHE_HOME", cache)
+	} else {
+		_ = os.MkdirAll(cache, 0700)
+	}
+	cleanup = func() {
+		os.Setenv("HOME", prevHome)
+		if prevXDG == "" {
+			os.Unsetenv("XDG_CONFIG_HOME")
+		} else {
+			os.Setenv("XDG_CONFIG_HOME", prevXDG)
+		}
+		if prevCache == "" {
+			os.Unsetenv("XDG_CACHE_HOME")
+		} else {
+			os.Setenv("XDG_CACHE_HOME", prevCache)
+		}
+	}
+	return home, cleanup
+}
+
+func readChromePath(t *testing.T) string {
+	t.Helper()
+	manifestPath := filepath.Join(natmsg.GetChromeNativeMessagingDir(), natmsg.ManifestFileName)
+	data, err := os.ReadFile(manifestPath)
+	if err != nil {
+		t.Fatalf("read manifest: %v", err)
+	}
+	var raw map[string]interface{}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	p, _ := raw["path"].(string)
+	return p
+}
+
+func TestBrowserHostWrapper_RoundTrip(t *testing.T) {
+	_, cleanup := withIsolatedHome(t)
+	defer cleanup()
+
+	tmp := t.TempDir()
+	hostPath := filepath.Join(tmp, "devlog-host")
+	if err := os.WriteFile(hostPath, []byte("#!/bin/sh\n"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	logPath := filepath.Join(tmp, "browser.log")
+
+	if err := natmsg.InstallChromeManifest(hostPath, "testid"); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+
+	if err := writeBrowserHostWrapperWithHost("test-session", logPath, []string{"error", "warn"}, hostPath); err != nil {
+		t.Fatalf("write wrapper: %v", err)
+	}
+
+	wrapperPath := browserHostWrapperPath("test-session")
+	if _, err := os.Stat(wrapperPath); err != nil {
+		t.Fatalf("wrapper missing: %v", err)
+	}
+	if runtime.GOOS != "windows" {
+		info, _ := os.Stat(wrapperPath)
+		if info.Mode().Perm() != 0700 {
+			t.Errorf("wrapper mode = %o, want 0700", info.Mode().Perm())
+		}
+	}
+	if got := readChromePath(t); got != wrapperPath {
+		t.Errorf("manifest path = %q, want wrapper %q", got, wrapperPath)
+	}
+
+	restoreBrowserHostWrapperWithHost("test-session", hostPath)
+
+	if _, err := os.Stat(wrapperPath); !os.IsNotExist(err) {
+		t.Errorf("wrapper should be deleted after restore")
+	}
+	if got := readChromePath(t); got != hostPath {
+		t.Errorf("manifest path after restore = %q, want host %q", got, hostPath)
+	}
+}
+
+func TestBrowserHostWrapper_StaleRecovery(t *testing.T) {
+	_, cleanup := withIsolatedHome(t)
+	defer cleanup()
+
+	tmp := t.TempDir()
+	hostPath := filepath.Join(tmp, "devlog-host")
+	if err := os.WriteFile(hostPath, []byte("#!/bin/sh\n"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	logPath := filepath.Join(tmp, "browser.log")
+
+	if err := natmsg.InstallChromeManifest(hostPath, "testid"); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+
+	// First up
+	if err := writeBrowserHostWrapperWithHost("sess-a", logPath, nil, hostPath); err != nil {
+		t.Fatalf("first write: %v", err)
+	}
+	wrapperPath := browserHostWrapperPath("sess-a")
+
+	// Simulate unclean shutdown: delete wrapper, leave manifest pointing at it
+	if err := os.Remove(wrapperPath); err != nil {
+		t.Fatal(err)
+	}
+	if got := readChromePath(t); got != wrapperPath {
+		t.Fatalf("precondition: manifest should still point at wrapper, got %q", got)
+	}
+
+	// Second up should self-heal and succeed
+	if err := writeBrowserHostWrapperWithHost("sess-a", logPath, []string{"error"}, hostPath); err != nil {
+		t.Fatalf("stale recovery write: %v", err)
+	}
+	if _, err := os.Stat(wrapperPath); err != nil {
+		t.Fatalf("wrapper not recreated: %v", err)
+	}
+	if got := readChromePath(t); got != wrapperPath {
+		t.Errorf("manifest path = %q, want %q", got, wrapperPath)
+	}
+}

--- a/cmd/devlog/cmd_healthcheck.go
+++ b/cmd/devlog/cmd_healthcheck.go
@@ -34,7 +34,8 @@ func cmdHealthcheck(cfg *config.Config, args []string) error {
 
 	// Check devlog-host binary
 	fmt.Printf("%-*s ", maxLabelLen, "devlog-host binary:")
-	hostPath, err := natmsg.FindDevlogHostBinary()
+	var hostPath string
+	hostPath, err = natmsg.FindDevlogHostBinary()
 	if err != nil {
 		fmt.Println("✗ NOT FOUND")
 		fmt.Println("  devlog-host is required for browser logging.")
@@ -90,6 +91,34 @@ func cmdHealthcheck(cfg *config.Config, args []string) error {
 		fmt.Println("            devlog register --brave --extension-id <id>")
 		fmt.Println("            devlog register --firefox")
 		allGood = false
+	}
+
+	// Check that manifest path targets exist on disk (self-heal when possible)
+	fmt.Printf("%-*s ", maxLabelLen, "Manifest host path:")
+	if hostPath != "" {
+		if repaired, err := natmsg.RepairStaleManifestPaths(hostPath); err == nil && repaired > 0 {
+			fmt.Printf("✓ repaired %d stale path(s)\n", repaired)
+		}
+	}
+	paths, pathErr := natmsg.ReadManifestPaths()
+	if pathErr != nil && len(paths) == 0 {
+		fmt.Println("○ none installed")
+	} else {
+		stale := 0
+		for _, p := range paths {
+			if _, err := os.Stat(p); err != nil {
+				stale++
+			}
+		}
+		if stale > 0 {
+			fmt.Printf("✗ %d path(s) missing on disk\n", stale)
+			fmt.Println("  Run: devlog up  (or re-register) to repair")
+			allGood = false
+		} else if len(paths) == 0 {
+			fmt.Println("○ none installed")
+		} else {
+			fmt.Printf("✓ %d path(s) exist\n", len(paths))
+		}
 	}
 
 	fmt.Println()

--- a/cmd/devlog/helpers.go
+++ b/cmd/devlog/helpers.go
@@ -96,8 +96,23 @@ func writeBrowserHostWrapper(session string, browserLogPath string, levels []str
 	if err != nil {
 		return err
 	}
+	return writeBrowserHostWrapperWithHost(session, browserLogPath, levels, hostPath)
+}
+
+// writeBrowserHostWrapperWithHost is the testable core of writeBrowserHostWrapper.
+func writeBrowserHostWrapperWithHost(session, browserLogPath string, levels []string, hostPath string) error {
 	if err := natmsg.ValidateHostPath(hostPath); err != nil {
 		return fmt.Errorf("untrusted host binary: %w", err)
+	}
+
+	// Self-heal: if a previous unclean shutdown left manifests pointing at a
+	// missing wrapper, restore them to the real binary before we rewrite.
+	if _, err := natmsg.RepairStaleManifestPaths(hostPath); err != nil {
+		// Non-fatal when no manifests exist yet.
+		if !strings.Contains(err.Error(), "failed to read some manifests") &&
+			!strings.Contains(err.Error(), "no native messaging") {
+			// continue; UpdateManifestPath will report clearer errors
+		}
 	}
 
 	absLogPath, err := filepath.Abs(browserLogPath)
@@ -152,14 +167,25 @@ func restoreBrowserHostWrapper(session string) {
 	if err != nil {
 		return
 	}
+	restoreBrowserHostWrapperWithHost(session, hostPath)
+}
 
+// restoreBrowserHostWrapperWithHost restores manifests that still point at this
+// session's wrapper (even if the wrapper file was already deleted) and removes
+// the wrapper file if present.
+func restoreBrowserHostWrapperWithHost(session, hostPath string) {
 	wrapperPath := browserHostWrapperPath(session)
+
+	// Restore if our wrapper is referenced, or if any path is missing (stale).
 	inUse, err := natmsg.IsManifestPathInUse(wrapperPath)
 	if err == nil && inUse {
-		natmsg.UpdateManifestPath(hostPath)
+		_ = natmsg.UpdateManifestPath(hostPath)
+	} else {
+		// Also repair any other stale missing paths back to the real binary.
+		_, _ = natmsg.RepairStaleManifestPaths(hostPath)
 	}
 
-	os.Remove(wrapperPath)
+	_ = os.Remove(wrapperPath)
 }
 
 // batchQuote returns a Windows batch-escaped argument using double quotes.


### PR DESCRIPTION
## Summary
Self-heal stale native messaging wrapper paths on `devlog up` / `healthcheck`, restore even when the wrapper file is gone, and add round-trip tests.

Depends on #52.

## Test plan
- [x] `go test ./cmd/devlog/ -run TestBrowserHost`
- [ ] CI green

Fixes #45

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Health checks now validate native-messaging manifest paths and report missing or repaired host targets.
  * Browser host setup can automatically recover from stale or missing wrapper paths.

* **Bug Fixes**
  * Improved cleanup restores native-messaging configuration to the correct host and removes temporary wrappers.
  * Added recovery for interrupted sessions and stale configuration entries.

* **Tests**
  * Added coverage for browser host wrapper creation, cleanup, permissions, and stale-state recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->