### PR TITLE
fix: refuse to clobber browser wrapper of a live session

### DIFF
--- a/cmd/devlog/browser_wrapper_test.go
+++ b/cmd/devlog/browser_wrapper_test.go
@@ -3,8 +3,10 @@ package main
 import (
 	"encoding/json"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/jellydn/devlog/internal/natmsg"
@@ -138,5 +140,85 @@ func TestBrowserHostWrapper_StaleRecovery(t *testing.T) {
 	}
 	if got := readChromePath(t); got != wrapperPath {
 		t.Errorf("manifest path = %q, want %q", got, wrapperPath)
+	}
+}
+
+func TestSessionFromWrapperPath(t *testing.T) {
+	tests := []struct {
+		path string
+		want string
+		ok   bool
+	}{
+		{filepath.Join("/tmp", "devlog", "wrappers", "devlog-host-wrapper-myapp.sh"), "myapp", true},
+		{filepath.Join("/tmp", "devlog", "wrappers", "devlog-host-wrapper-myapp.bat"), "myapp", true},
+		{filepath.Join("/tmp", "devlog-host"), "", false},
+		{filepath.Join("/tmp", "devlog", "wrappers", "devlog-host-wrapper-.sh"), "", false},
+	}
+	for _, tt := range tests {
+		got, ok := sessionFromWrapperPath(tt.path)
+		if ok != tt.ok || got != tt.want {
+			t.Errorf("sessionFromWrapperPath(%q) = (%q, %v), want (%q, %v)", tt.path, got, ok, tt.want, tt.ok)
+		}
+	}
+}
+
+func TestRefuseClobberActiveWrapper_SameSessionAllowed(t *testing.T) {
+	_, cleanup := withIsolatedHome(t)
+	defer cleanup()
+
+	tmp := t.TempDir()
+	hostPath := filepath.Join(tmp, "devlog-host")
+	if err := os.WriteFile(hostPath, []byte("#!/bin/sh\n"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := natmsg.InstallChromeManifest(hostPath, "testid"); err != nil {
+		t.Fatal(err)
+	}
+	logPath := filepath.Join(tmp, "b.log")
+	if err := writeBrowserHostWrapperWithHost("same", logPath, nil, hostPath); err != nil {
+		t.Fatal(err)
+	}
+	// Rewriting for the same session should be allowed even without a live tmux session
+	if err := writeBrowserHostWrapperWithHost("same", logPath, []string{"error"}, hostPath); err != nil {
+		t.Fatalf("same session rewrite should be allowed: %v", err)
+	}
+}
+
+func TestRefuseClobberActiveWrapper_OtherLiveSession(t *testing.T) {
+	if _, err := exec.LookPath("tmux"); err != nil {
+		t.Skip("tmux not available")
+	}
+	_, cleanup := withIsolatedHome(t)
+	defer cleanup()
+
+	tmp := t.TempDir()
+	hostPath := filepath.Join(tmp, "devlog-host")
+	if err := os.WriteFile(hostPath, []byte("#!/bin/sh\n"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := natmsg.InstallChromeManifest(hostPath, "testid"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a live tmux session named other-live
+	session := "other-live"
+	_ = exec.Command("tmux", "kill-session", "-t", session).Run()
+	if err := exec.Command("tmux", "new-session", "-d", "-s", session).Run(); err != nil {
+		t.Skipf("could not create tmux session: %v", err)
+	}
+	defer exec.Command("tmux", "kill-session", "-t", session).Run()
+
+	logPath := filepath.Join(tmp, "b.log")
+	if err := writeBrowserHostWrapperWithHost(session, logPath, nil, hostPath); err != nil {
+		t.Fatalf("setup other session wrapper: %v", err)
+	}
+
+	// Attempt to clobber from a different session while other is live
+	err := writeBrowserHostWrapperWithHost("new-session", logPath, nil, hostPath)
+	if err == nil {
+		t.Fatal("expected clobber refusal when other session is live")
+	}
+	if !strings.Contains(err.Error(), "already in use") {
+		t.Errorf("error = %q, want already in use", err.Error())
 	}
 }

--- a/cmd/devlog/helpers.go
+++ b/cmd/devlog/helpers.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/jellydn/devlog/internal/natmsg"
 	"github.com/jellydn/devlog/internal/shellescape"
+	"github.com/jellydn/devlog/internal/tmux"
 )
 
 func findConfigFile() string {
@@ -121,6 +122,10 @@ func writeBrowserHostWrapperWithHost(session, browserLogPath string, levels []st
 	}
 
 	wrapperPath := browserHostWrapperPath(session)
+	if err := refuseClobberActiveWrapper(wrapperPath); err != nil {
+		return err
+	}
+
 	if err := os.MkdirAll(filepath.Dir(wrapperPath), 0700); err != nil {
 		return err
 	}
@@ -140,6 +145,56 @@ func writeBrowserHostWrapperWithHost(session, browserLogPath string, levels []st
 	}
 
 	return nil
+}
+
+// refuseClobberActiveWrapper returns an error if any installed manifest currently
+// points at a different session's wrapper whose tmux session is still alive.
+func refuseClobberActiveWrapper(desiredWrapper string) error {
+	desiredWrapper = filepath.Clean(desiredWrapper)
+	paths, err := natmsg.ReadManifestPaths()
+	if err != nil && len(paths) == 0 {
+		// No manifests installed yet — nothing to clobber.
+		return nil
+	}
+	for _, current := range paths {
+		current = filepath.Clean(current)
+		if current == desiredWrapper {
+			continue
+		}
+		otherSession, ok := sessionFromWrapperPath(current)
+		if !ok {
+			continue
+		}
+		// Only refuse when the other wrapper still exists AND its session is live.
+		if _, statErr := os.Stat(current); statErr != nil {
+			continue
+		}
+		if tmux.NewRunner(otherSession).SessionExists() {
+			return fmt.Errorf("browser logging is already in use by session %q; run 'devlog down' in that session first", otherSession)
+		}
+	}
+	return nil
+}
+
+// sessionFromWrapperPath extracts the session name from a wrapper path like
+// .../devlog-host-wrapper-<session>.sh|.bat
+func sessionFromWrapperPath(path string) (string, bool) {
+	base := filepath.Base(path)
+	const prefix = "devlog-host-wrapper-"
+	if !strings.HasPrefix(base, prefix) {
+		return "", false
+	}
+	name := strings.TrimPrefix(base, prefix)
+	for _, ext := range []string{".sh", ".bat"} {
+		if strings.HasSuffix(name, ext) {
+			name = strings.TrimSuffix(name, ext)
+			break
+		}
+	}
+	if name == "" {
+		return "", false
+	}
+	return name, true
 }
 
 func generateShellScript(hostPath, absLogPath string, levels []string) string {


### PR DESCRIPTION
## Summary
Refuse to rewrite the native messaging host path when another live devlog session already owns the wrapper, preventing silent cross-project log contamination.

Depends on #53.

## Test plan
- [x] `go test ./cmd/devlog/ -run 'TestRefuse|TestSessionFrom'`
- [ ] CI green

Fixes #46