### PR TITLE
refactor: extract internal/manifest from natmsg

### DIFF
--- a/cmd/devlog/browser_wrapper_test.go
+++ b/cmd/devlog/browser_wrapper_test.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/jellydn/devlog/internal/natmsg"
+	"github.com/jellydn/devlog/internal/manifest"
 )
 
 func withIsolatedHome(t *testing.T) (home string, cleanup func()) {
@@ -46,7 +46,7 @@ func withIsolatedHome(t *testing.T) (home string, cleanup func()) {
 
 func readChromePath(t *testing.T) string {
 	t.Helper()
-	manifestPath := filepath.Join(natmsg.GetChromeNativeMessagingDir(), natmsg.ManifestFileName)
+	manifestPath := filepath.Join(manifest.GetChromeNativeMessagingDir(), manifest.ManifestFileName)
 	data, err := os.ReadFile(manifestPath)
 	if err != nil {
 		t.Fatalf("read manifest: %v", err)
@@ -70,7 +70,7 @@ func TestBrowserHostWrapper_RoundTrip(t *testing.T) {
 	}
 	logPath := filepath.Join(tmp, "browser.log")
 
-	if err := natmsg.InstallChromeManifest(hostPath, "testid"); err != nil {
+	if err := manifest.InstallChromeManifest(hostPath, "testid"); err != nil {
 		t.Fatalf("install: %v", err)
 	}
 
@@ -113,7 +113,7 @@ func TestBrowserHostWrapper_StaleRecovery(t *testing.T) {
 	}
 	logPath := filepath.Join(tmp, "browser.log")
 
-	if err := natmsg.InstallChromeManifest(hostPath, "testid"); err != nil {
+	if err := manifest.InstallChromeManifest(hostPath, "testid"); err != nil {
 		t.Fatalf("install: %v", err)
 	}
 
@@ -171,7 +171,7 @@ func TestRefuseClobberActiveWrapper_SameSessionAllowed(t *testing.T) {
 	if err := os.WriteFile(hostPath, []byte("#!/bin/sh\n"), 0755); err != nil {
 		t.Fatal(err)
 	}
-	if err := natmsg.InstallChromeManifest(hostPath, "testid"); err != nil {
+	if err := manifest.InstallChromeManifest(hostPath, "testid"); err != nil {
 		t.Fatal(err)
 	}
 	logPath := filepath.Join(tmp, "b.log")
@@ -196,7 +196,7 @@ func TestRefuseClobberActiveWrapper_OtherLiveSession(t *testing.T) {
 	if err := os.WriteFile(hostPath, []byte("#!/bin/sh\n"), 0755); err != nil {
 		t.Fatal(err)
 	}
-	if err := natmsg.InstallChromeManifest(hostPath, "testid"); err != nil {
+	if err := manifest.InstallChromeManifest(hostPath, "testid"); err != nil {
 		t.Fatal(err)
 	}
 

--- a/cmd/devlog/cmd_healthcheck.go
+++ b/cmd/devlog/cmd_healthcheck.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	"github.com/jellydn/devlog/internal/config"
-	"github.com/jellydn/devlog/internal/natmsg"
+	"github.com/jellydn/devlog/internal/manifest"
 	"github.com/jellydn/devlog/internal/tmux"
 )
 
@@ -35,7 +35,7 @@ func cmdHealthcheck(cfg *config.Config, args []string) error {
 	// Check devlog-host binary
 	fmt.Printf("%-*s ", maxLabelLen, "devlog-host binary:")
 	var hostPath string
-	hostPath, err = natmsg.FindDevlogHostBinary()
+	hostPath, err = manifest.FindDevlogHostBinary()
 	if err != nil {
 		fmt.Println("✗ NOT FOUND")
 		fmt.Println("  devlog-host is required for browser logging.")
@@ -47,10 +47,10 @@ func cmdHealthcheck(cfg *config.Config, args []string) error {
 
 	// Check native messaging manifests
 	fmt.Printf("%-*s ", maxLabelLen, "Browser extension:")
-	chromeManifestPath := filepath.Join(natmsg.GetChromeNativeMessagingDir(), "com.devlog.host.json")
-	braveManifestPath := filepath.Join(natmsg.GetBraveNativeMessagingDir(), "com.devlog.host.json")
+	chromeManifestPath := filepath.Join(manifest.GetChromeNativeMessagingDir(), "com.devlog.host.json")
+	braveManifestPath := filepath.Join(manifest.GetBraveNativeMessagingDir(), "com.devlog.host.json")
 	firefoxManifestPaths := []string{}
-	for _, dir := range natmsg.GetFirefoxNativeMessagingDirs() {
+	for _, dir := range manifest.GetFirefoxNativeMessagingDirs() {
 		firefoxManifestPaths = append(firefoxManifestPaths, filepath.Join(dir, "com.devlog.host.json"))
 	}
 
@@ -96,11 +96,11 @@ func cmdHealthcheck(cfg *config.Config, args []string) error {
 	// Check that manifest path targets exist on disk (self-heal when possible)
 	fmt.Printf("%-*s ", maxLabelLen, "Manifest host path:")
 	if hostPath != "" {
-		if repaired, err := natmsg.RepairStaleManifestPaths(hostPath); err == nil && repaired > 0 {
+		if repaired, err := manifest.RepairStaleManifestPaths(hostPath); err == nil && repaired > 0 {
 			fmt.Printf("✓ repaired %d stale path(s)\n", repaired)
 		}
 	}
-	paths, pathErr := natmsg.ReadManifestPaths()
+	paths, pathErr := manifest.ReadManifestPaths()
 	if pathErr != nil && len(paths) == 0 {
 		fmt.Println("○ none installed")
 	} else {

--- a/cmd/devlog/cmd_register.go
+++ b/cmd/devlog/cmd_register.go
@@ -4,11 +4,11 @@ import (
 	"fmt"
 
 	"github.com/jellydn/devlog/internal/config"
-	"github.com/jellydn/devlog/internal/natmsg"
+	"github.com/jellydn/devlog/internal/manifest"
 )
 
 func cmdRegister(cfg *config.Config, args []string) error {
-	hostPath, err := natmsg.FindDevlogHostBinary()
+	hostPath, err := manifest.FindDevlogHostBinary()
 	if err != nil {
 		return fmt.Errorf("failed to find devlog-host binary: %w", err)
 	}
@@ -73,19 +73,19 @@ Examples:
 
 	if installChrome {
 		fmt.Printf("Registering for Chrome...\n")
-		if err := natmsg.InstallChromeManifest(hostPath, extensionID); err != nil {
+		if err := manifest.InstallChromeManifest(hostPath, extensionID); err != nil {
 			return fmt.Errorf("failed to register Chrome manifest: %w", err)
 		}
-		dir := natmsg.GetChromeNativeMessagingDir()
+		dir := manifest.GetChromeNativeMessagingDir()
 		fmt.Printf("  Installed to: %s\n", dir)
 	}
 
 	if installBrave {
 		fmt.Printf("Registering for Brave...\n")
-		if err := natmsg.InstallBraveManifest(hostPath, extensionID); err != nil {
+		if err := manifest.InstallBraveManifest(hostPath, extensionID); err != nil {
 			return fmt.Errorf("failed to register Brave manifest: %w", err)
 		}
-		dir := natmsg.GetBraveNativeMessagingDir()
+		dir := manifest.GetBraveNativeMessagingDir()
 		fmt.Printf("  Installed to: %s\n", dir)
 	}
 
@@ -96,10 +96,10 @@ Examples:
 		if firefoxExtID == "" {
 			firefoxExtID = "devlog@devlog.local"
 		}
-		if err := natmsg.InstallFirefoxManifestWithID(hostPath, firefoxExtID); err != nil {
+		if err := manifest.InstallFirefoxManifestWithID(hostPath, firefoxExtID); err != nil {
 			return fmt.Errorf("failed to register Firefox manifest: %w", err)
 		}
-		dirs := natmsg.GetFirefoxNativeMessagingDirs()
+		dirs := manifest.GetFirefoxNativeMessagingDirs()
 		fmt.Printf("  Installed to:\n")
 		for _, dir := range dirs {
 			fmt.Printf("    - %s\n", dir)

--- a/cmd/devlog/helpers.go
+++ b/cmd/devlog/helpers.go
@@ -7,7 +7,7 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/jellydn/devlog/internal/natmsg"
+	"github.com/jellydn/devlog/internal/manifest"
 	"github.com/jellydn/devlog/internal/shellescape"
 	"github.com/jellydn/devlog/internal/tmux"
 )
@@ -93,7 +93,7 @@ func sanitizeSessionForFileName(session string) string {
 }
 
 func writeBrowserHostWrapper(session string, browserLogPath string, levels []string) error {
-	hostPath, err := natmsg.FindDevlogHostBinary()
+	hostPath, err := manifest.FindDevlogHostBinary()
 	if err != nil {
 		return err
 	}
@@ -102,13 +102,13 @@ func writeBrowserHostWrapper(session string, browserLogPath string, levels []str
 
 // writeBrowserHostWrapperWithHost is the testable core of writeBrowserHostWrapper.
 func writeBrowserHostWrapperWithHost(session, browserLogPath string, levels []string, hostPath string) error {
-	if err := natmsg.ValidateHostPath(hostPath); err != nil {
+	if err := manifest.ValidateHostPath(hostPath); err != nil {
 		return fmt.Errorf("untrusted host binary: %w", err)
 	}
 
 	// Self-heal: if a previous unclean shutdown left manifests pointing at a
 	// missing wrapper, restore them to the real binary before we rewrite.
-	if _, err := natmsg.RepairStaleManifestPaths(hostPath); err != nil {
+	if _, err := manifest.RepairStaleManifestPaths(hostPath); err != nil {
 		// Non-fatal when no manifests exist yet.
 		if !strings.Contains(err.Error(), "failed to read some manifests") &&
 			!strings.Contains(err.Error(), "no native messaging") {
@@ -140,7 +140,7 @@ func writeBrowserHostWrapperWithHost(session, browserLogPath string, levels []st
 		return err
 	}
 
-	if err := natmsg.UpdateManifestPath(wrapperPath); err != nil {
+	if err := manifest.UpdateManifestPath(wrapperPath); err != nil {
 		return fmt.Errorf("failed to update native messaging manifest: %w", err)
 	}
 
@@ -151,7 +151,7 @@ func writeBrowserHostWrapperWithHost(session, browserLogPath string, levels []st
 // points at a different session's wrapper whose tmux session is still alive.
 func refuseClobberActiveWrapper(desiredWrapper string) error {
 	desiredWrapper = filepath.Clean(desiredWrapper)
-	paths, err := natmsg.ReadManifestPaths()
+	paths, err := manifest.ReadManifestPaths()
 	if err != nil && len(paths) == 0 {
 		// No manifests installed yet — nothing to clobber.
 		return nil
@@ -218,7 +218,7 @@ func generateBatchScript(hostPath, absLogPath string, levels []string) string {
 }
 
 func restoreBrowserHostWrapper(session string) {
-	hostPath, err := natmsg.FindDevlogHostBinary()
+	hostPath, err := manifest.FindDevlogHostBinary()
 	if err != nil {
 		return
 	}
@@ -232,12 +232,12 @@ func restoreBrowserHostWrapperWithHost(session, hostPath string) {
 	wrapperPath := browserHostWrapperPath(session)
 
 	// Restore if our wrapper is referenced, or if any path is missing (stale).
-	inUse, err := natmsg.IsManifestPathInUse(wrapperPath)
+	inUse, err := manifest.IsManifestPathInUse(wrapperPath)
 	if err == nil && inUse {
-		_ = natmsg.UpdateManifestPath(hostPath)
+		_ = manifest.UpdateManifestPath(hostPath)
 	} else {
 		// Also repair any other stale missing paths back to the real binary.
-		_, _ = natmsg.RepairStaleManifestPaths(hostPath)
+		_, _ = manifest.RepairStaleManifestPaths(hostPath)
 	}
 
 	_ = os.Remove(wrapperPath)

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -1,4 +1,4 @@
-package natmsg
+package manifest
 
 import (
 	"encoding/json"

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -1,4 +1,4 @@
-package natmsg
+package manifest
 
 import (
 	"encoding/json"

--- a/internal/manifest/validate_host_unix.go
+++ b/internal/manifest/validate_host_unix.go
@@ -1,6 +1,6 @@
 //go:build !windows
 
-package natmsg
+package manifest
 
 import (
 	"fmt"

--- a/internal/manifest/validate_host_windows.go
+++ b/internal/manifest/validate_host_windows.go
@@ -1,6 +1,6 @@
 //go:build windows
 
-package natmsg
+package manifest
 
 import (
 	"fmt"


### PR DESCRIPTION
## Summary

Extracts all manifest/registration operations from `internal/natmsg` into a new `internal/manifest` module so the protocol package stays focused on length-prefixed JSON over stdio.

Closes #66

## What moved

- `ChromeManifest` / `FirefoxManifest` and install helpers
- Native messaging dir getters
- `UpdateManifestPath`, `IsManifestPathInUse`, `ReadManifestPaths`, `RepairStaleManifestPaths`
- `FindDevlogHostBinary`, `ManifestFileName`, `ManifestDirs`
- `ValidateHostPath` (unix/windows build tags)
- `manifest_test.go`

## What stays in `internal/natmsg`

Protocol types only: `Host`, `Message`, `Response`, read/write helpers.

## Callers updated

- `cmd/devlog/helpers.go`
- `cmd/devlog/cmd_register.go`
- `cmd/devlog/cmd_healthcheck.go`
- `cmd/devlog/browser_wrapper_test.go`

`cmd/devlog-host` unchanged (protocol only).

## Stack

1. **This PR** — #66 extract `internal/manifest`
2. #71 — #68 extract `internal/logrotate`
3. #72 — #67 extract `internal/browsersession`
4. #73 — #69 deepen `tmux.Runner` with `SessionConfig`

## Test plan

- [x] `go vet ./...`
- [x] `go test -short ./...`
- [x] No `internal/manifest` ↔ `internal/natmsg` imports