### PR TITLE
chore: post-refactor cleanup — docs, ADR, HealthCheck, fileutil, release workflow, simplify manifest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,7 @@ jobs:
   multi-platform:
     name: Build verification (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
@@ -99,7 +100,19 @@ jobs:
 
       - name: Install tmux (macOS)
         if: runner.os == 'macOS'
-        run: brew install tmux
+        env:
+          HOMEBREW_NO_AUTO_UPDATE: "1"
+          HOMEBREW_NO_INSTALL_CLEANUP: "1"
+        run: |
+          # Retry up to 3 times — Homebrew downloads occasionally time out on CI.
+          for i in 1 2 3; do
+            echo "Attempt $i: installing tmux..."
+            brew install tmux && exit 0
+            echo "Attempt $i failed, waiting 10s before retry..."
+            sleep 10
+          done
+          echo "brew install tmux failed after 3 attempts"
+          exit 1
 
       - name: Check formatting
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,9 @@ jobs:
       - name: Run integration tests
         run: go test -tags=integration ./internal/tmux/
 
+      - name: Run e2e tests
+        run: go test -tags=e2e -v ./internal/e2e/
+
       - name: Build devlog
         run: go build ./cmd/devlog
 

--- a/.github/workflows/release-extension.yml
+++ b/.github/workflows/release-extension.yml
@@ -1,0 +1,152 @@
+name: Release Extension
+
+on:
+  push:
+    tags: ["ext-v*"]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Extension version (leave empty to use VERSION file)'
+        required: false
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  test:
+    name: Test extension
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: browser-extension
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: "24"
+          cache: npm
+          cache-dependency-path: browser-extension/package-lock.json
+      - name: Install dependencies
+        run: npm ci
+      - name: Run extension tests
+        run: npm test
+
+  package:
+    name: Package extensions
+    needs: test
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Read or set version
+        id: version
+        run: |
+          if [ -n "${{ inputs.version }}" ]; then
+            echo "${{ inputs.version }}" > browser-extension/VERSION
+          fi
+          VERSION=$(cat browser-extension/VERSION)
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Update manifest versions
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          sed -i 's/"version": "[^"]*"/"version": "'"$VERSION"'"/' browser-extension/chrome/manifest.json
+          sed -i 's/"version": "[^"]*"/"version": "'"$VERSION"'"/' browser-extension/firefox/manifest.json
+
+      - name: Package Chrome
+        run: bash scripts/package-chrome.sh
+
+      - name: Package Firefox
+        run: bash scripts/package-firefox.sh
+
+      - name: Upload Chrome artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: devlog-chrome
+          path: dist/devlog-chrome-v*.zip
+
+      - name: Upload Firefox artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: devlog-firefox
+          path: dist/devlog-firefox-v*.zip
+
+  publish-chrome:
+    name: Publish Chrome Web Store
+    needs: package
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/setup-node@v7
+        with:
+          node-version: "24"
+      - uses: actions/download-artifact@v4
+        with:
+          name: devlog-chrome
+          path: dist/
+      - name: Upload to Chrome Web Store
+        run: |
+          ZIP=$(ls dist/devlog-chrome-v*.zip)
+          npx chrome-webstore-upload-cli upload \
+            --source "$ZIP" \
+            --extension-id "$EXTENSION_ID" \
+            --auto-publish
+        env:
+          CLIENT_ID: ${{ secrets.CHROME_CLIENT_ID }}
+          CLIENT_SECRET: ${{ secrets.CHROME_CLIENT_SECRET }}
+          REFRESH_TOKEN: ${{ secrets.CHROME_REFRESH_TOKEN }}
+          EXTENSION_ID: ${{ vars.CHROME_EXTENSION_ID }}
+
+  publish-firefox:
+    name: Publish Firefox Add-ons
+    needs: package
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: "24"
+      - name: Update manifest version
+        run: |
+          VERSION="${{ needs.package.outputs.version }}"
+          sed -i 's/"version": "[^"]*"/"version": "'"$VERSION"'"/' browser-extension/firefox/manifest.json
+      - name: Sign and publish to Firefox Add-ons
+        run: |
+          npx web-ext sign \
+            --source-dir browser-extension/firefox \
+            --channel listed
+        env:
+          WEB_EXT_API_KEY: ${{ secrets.FIREFOX_JWT_ISSUER }}
+          WEB_EXT_API_SECRET: ${{ secrets.FIREFOX_JWT_SECRET }}
+
+  release:
+    name: Create GitHub Release
+    needs: [package, publish-chrome, publish-firefox]
+    if: always() && needs.package.result == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: devlog-chrome
+          path: dist/
+      - uses: actions/download-artifact@v4
+        with:
+          name: devlog-firefox
+          path: dist/
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          files: dist/*.zip
+          generate_release_notes: true
+          body: |
+            ## Store Publish Status
+            - Chrome Web Store: ${{ needs.publish-chrome.result }}
+            - Firefox Add-ons: ${{ needs.publish-firefox.result }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.planning/codebase/ARCHITECTURE.md
+++ b/.planning/codebase/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Architecture
 
-**Analysis Date:** 2026-07-19
+**Analysis Date:** 2026-07-19 (regenerated)
 
 ## Pattern Overview
 **Overall:** Multi-binary CLI tool with browser extension sidecar
@@ -11,14 +11,15 @@
 - YAML-driven configuration with environment variable interpolation
 - Append-only log files with timestamped run directories for isolation
 - Minimal dependencies — only `gopkg.in/yaml.v3` beyond the Go standard library
+- Interface-based dependency injection for testability (`ManifestOps`, `SessionChecker`)
 
 ## Layers
 
 **CLI Layer (cmd/devlog):**
 - Purpose: User-facing command dispatcher for managing dev logging sessions
-- Location: `cmd/devlog/main.go` (dispatcher) + `cmd/devlog/cmd_*.go` (one file per command) + `cmd/devlog/helpers.go` (shared helpers)
-- Contains: Command definitions (`cmdUp`, `cmdDown`, `cmdAttach`, `cmdStatus`, `cmdLs`, `cmdOpen`, `cmdInit`, `cmdRegister`, `cmdHealthcheck`), config discovery (`findConfigFile`), shell wrapper generation
-- Depends on: `internal/config`, `internal/tmux`, `internal/natmsg`, `internal/shellescape`
+- Location: `cmd/devlog/main.go` (dispatcher) + `cmd/devlog/cmd_*.go` (one file per command) + `cmd/devlog/helpers.go` (shared helpers) + `cmd/devlog/browser_session_adapter.go` (DI adapters)
+- Contains: Command definitions (`cmdUp`, `cmdDown`, `cmdAttach`, `cmdStatus`, `cmdLs`, `cmdOpen`, `cmdInit`, `cmdRegister`, `cmdHealthcheck`), config discovery (`findConfigFile`), file creation utility (`ensureFileExists`)
+- Depends on: `internal/config`, `internal/tmux`, `internal/manifest`, `internal/browsersession`, `internal/logrotate`, `internal/fileutil`, `internal/shellescape`
 - Used by: End users via terminal
 
 **Native Messaging Host Layer (cmd/devlog-host):**
@@ -29,25 +30,46 @@
 - Used by: Browser extension (launched by the browser as a native messaging host process)
 
 **Configuration Layer:**
-- Purpose: YAML config loading, validation, environment variable interpolation, retention policy cleanup
+- Purpose: YAML config loading, validation, environment variable interpolation
 - Location: `internal/config/config.go`
-- Contains: `Config`, `TmuxConfig`, `WindowConfig`, `PaneConfig`, `BrowserConfig` structs; `Load()`, `Validate()`, `ResolveLogsDir()`, `CleanupOldRuns()` functions
+- Contains: `Config`, `TmuxConfig`, `WindowConfig`, `PaneConfig`, `BrowserConfig` structs; `Load()`, `Validate()` functions
 - Depends on: `gopkg.in/yaml.v3`
 - Used by: CLI layer
 
 **Tmux Layer:**
-- Purpose: Manages tmux sessions, windows, and panes with pipe-pane log capture
+- Purpose: Manages tmux sessions, windows, and panes with pipe-pane log capture. Owns log-directory resolution.
 - Location: `internal/tmux/tmux.go`
-- Contains: `Runner` struct with session lifecycle methods (`CreateSession`, `KillSession`, `SessionExists`, `GetSessionInfo`); `WindowConfig`, `PaneConfig` (local duplicates for decoupling)
-- Depends on: `tmux` binary (external process via `os/exec`)
+- Contains: `Runner` struct with session lifecycle methods (`CreateSession`, `KillSession`, `SessionExists`, `GetSessionInfo`, `GetLogsDir`); `SessionConfig` (bundles session name, logs dir, run mode, windows)
+- Depends on: `internal/config` (for `WindowConfig`/`PaneConfig` types), `internal/fileutil`, `internal/shellescape`, `tmux` binary (external process via `os/exec`)
 - Used by: CLI layer
 
 **Native Messaging Protocol Layer:**
-- Purpose: Implements the browser Native Messaging wire protocol (length-prefixed JSON over stdin/stdout) and manages browser manifest registration
-- Location: `internal/natmsg/natmsg.go`, `internal/natmsg/manifest.go`
-- Contains: `Host` (read/write messages), `Message`/`Response` types, `Timestamp` with flexible unmarshaling, manifest install/update functions for Chrome/Brave/Firefox
+- Purpose: Implements the browser Native Messaging wire protocol (length-prefixed JSON over stdin/stdout)
+- Location: `internal/natmsg/natmsg.go`
+- Contains: `Host` (read/write messages), `Message`/`Response` types, `Timestamp` with flexible unmarshaling
 - Depends on: Standard library only
-- Used by: `devlog-host` binary, CLI layer (for `register` and `healthcheck` commands)
+- Used by: `devlog-host` binary
+
+**Manifest Layer:**
+- Purpose: Manages browser native messaging host registration — installing, updating, and repairing manifest JSON files
+- Location: `internal/manifest/manifest.go`, `internal/manifest/validate_host_*.go`
+- Contains: `ChromeManifest`, `FirefoxManifest` structs; install/update/repair functions for Chrome/Brave/Firefox/Zen; OS-specific `ValidateHostPath` (build-tagged)
+- Depends on: Standard library only
+- Used by: CLI layer (via `browsersession.ManifestOps` interface), `cmd_register.go`
+
+**Browser Session Layer:**
+- Purpose: Manages browser-log capture lifecycle — wrapper script creation/destruction, clobber protection, health checks
+- Location: `internal/browsersession/session.go`
+- Contains: `Session` struct with `Start`/`Stop`/`HealthCheck`; `ManifestOps` and `SessionChecker` interfaces for DI
+- Depends on: `internal/shellescape` (for wrapper script generation)
+- Used by: CLI layer (`cmd_up.go`, `cmd_down.go`, `cmd_healthcheck.go`)
+
+**Log Rotation Layer:**
+- Purpose: Cleans up old timestamped log directories based on retention policy
+- Location: `internal/logrotate/logrotate.go`
+- Contains: `Policy`, `Result` structs; `Cleanup` function
+- Depends on: Standard library only
+- Used by: CLI layer (`cmd_up.go`)
 
 **Logger Layer:**
 - Purpose: Writes formatted, level-filtered browser log messages to append-only files
@@ -55,6 +77,13 @@
 - Contains: `Logger` struct with mutex-protected file writes, level filtering
 - Depends on: `internal/natmsg` (for `Message` type)
 - Used by: `devlog-host` binary
+
+**File Utilities Layer:**
+- Purpose: Shared filesystem helper functions
+- Location: `internal/fileutil/touchfile.go`
+- Contains: `TouchFile` — ensures a file exists (MkdirAll + OpenFile + Close)
+- Depends on: Standard library only
+- Used by: `cmd/devlog/helpers.go`, `internal/tmux/tmux.go`
 
 **Browser Extension Layer:**
 - Purpose: Captures browser console logs from web pages and forwards them to the native host
@@ -67,22 +96,29 @@
 
 **Server Log Capture (tmux pipe-pane):**
 1. User runs `devlog up` → CLI loads `devlog.yml` config
-2. CLI creates tmux session with windows/panes via `tmux.Runner.CreateSession()`
-3. Each pane runs its configured command with `tmux pipe-pane` capturing stdout to a log file
-4. Log files are written to `<logs_dir>/<timestamp>/` (timestamped mode) or `<logs_dir>/` (overwrite mode)
-5. User runs `devlog down` → CLI sends Ctrl+C to all panes, then kills the tmux session
+2. CLI constructs `tmux.SessionConfig` and calls `runner.CreateSession()`
+3. Runner resolves logs directory (timestamped subdirectory if needed), stores it internally, creates the directory, and ensures pane log files via `fileutil.TouchFile`
+4. Each pane runs its configured command with `tmux pipe-pane` capturing stdout to a log file
+5. Log files are written to `<logs_dir>/<timestamp>/` (timestamped mode) or `<logs_dir>/` (overwrite mode)
+6. `DEVLOG_LOGS_DIR` is set as a tmux session environment variable for external tool access
+7. User runs `devlog down` → CLI sends Ctrl+C to all panes, then kills the tmux session; also restores browser manifest path via `browsersession.Session.Stop()`
 
 **Browser Log Capture (native messaging):**
-1. `devlog up` generates a shell wrapper script at `~/Library/Caches/devlog/wrappers/devlog-host-wrapper-<session>.sh` that calls `devlog-host` with the correct log path and level filters
-2. The wrapper path is written into the browser's native messaging manifest (`com.devlog.host.json`)
+1. `devlog up` → `browsersession.Session.Start()` generates a wrapper script at `~/Library/Caches/devlog/wrappers/devlog-host-wrapper-<session>.sh`
+2. The wrapper path is written into the browser's native messaging manifest (`com.devlog.host.json`) via `ManifestOps.UpdateManifestPath`
 3. In the browser, `page_inject.js` wraps `console.*` methods and posts messages to `content_script.js` via `window.postMessage`
 4. `content_script.js` forwards matching messages to `background.js` via `chrome.runtime.sendMessage`
 5. `background.js` checks URL patterns, then sends the log message via `chrome.runtime.connectNative` → native messaging port
 6. The browser launches `devlog-host` (via the wrapper), which reads length-prefixed JSON from stdin and writes formatted lines to the log file
-7. `devlog down` restores the original binary path in the native messaging manifest
+7. `devlog down` → `browsersession.Session.Stop()` restores the original binary path in the native messaging manifest
+
+**Log Cleanup:**
+1. On `devlog up`, if `run_mode: timestamped`, `logrotate.Cleanup()` is called
+2. Old directories exceeding `max_runs` count or older than `retention_days` are removed
 
 **State Management:**
 - Session state is stored in tmux itself (session existence, environment variables like `DEVLOG_LOGS_DIR`)
+- `tmux.Runner` also caches the resolved `logsDir` in-memory for fast access via `GetLogsDir()`
 - No database or persistent state file — the filesystem (log directories) and tmux are the sources of truth
 - Browser extension state is in-memory only (connection status, config)
 
@@ -94,9 +130,14 @@
 - Pattern: Function-as-value command dispatch via `map[string]Command`
 
 **tmux.Runner:**
-- Purpose: Encapsulates all tmux subprocess interactions for a named session
+- Purpose: Encapsulates all tmux subprocess interactions for a named session. Owns log-directory resolution and storage.
 - Examples: `internal/tmux/tmux.go`
-- Pattern: Constructor injection (`NewRunner(sessionName)`) with method-based API
+- Pattern: Constructor injection (`NewRunner(sessionName)`) with method-based API; `SessionConfig` bundles all creation-time parameters
+
+**browsersession.Session:**
+- Purpose: Manages browser-log capture lifecycle with interface-based DI for testability
+- Examples: `internal/browsersession/session.go`
+- Pattern: Constructor injection (`New(manifest ManifestOps, tmux SessionChecker)`) with `Start`/`Stop`/`HealthCheck` API
 
 **natmsg.Host:**
 - Purpose: Abstracts Native Messaging wire protocol (stdin/stdout read/write with length prefix)
@@ -104,7 +145,7 @@
 - Pattern: Stream-based I/O with `NewHostWithStreams()` for testability
 
 **config.Config:**
-- Purpose: Strongly-typed representation of `devlog.yml` with validation and derived paths
+- Purpose: Strongly-typed representation of `devlog.yml` with validation
 - Examples: `internal/config/config.go`
 - Pattern: Load → Interpolate → Unmarshal → Default → Validate pipeline
 
@@ -147,7 +188,7 @@
 - Validation at load time with descriptive error messages
 
 **Security:**
-- Shell command injection prevention via single-quote escaping (`shellQuote()`)
+- Shell command injection prevention via single-quote escaping (`shellescape.Quote()`)
 - Tmux `pipe-pane` paths are escaped
 - Native messaging message size capped at 10MB
 - Browser extension uses `web_accessible_resources` for page injection (avoids CSP issues)
@@ -158,4 +199,4 @@
 - Supports Chrome, Brave, Firefox, and Zen browser
 
 ---
-*Architecture analysis: 2026-07-19*
+*Architecture analysis: 2026-07-19 (regenerated)*

--- a/.planning/codebase/CONVENTIONS.md
+++ b/.planning/codebase/CONVENTIONS.md
@@ -1,35 +1,35 @@
 # Coding Conventions
 
-**Analysis Date:** 2026-07-19
+**Analysis Date:** 2026-07-19 (regenerated)
 
 ## Naming Patterns
 
 **Files:**
-- Go source files: lowercase, no separators (`config.go`, `natmsg.go`, `manifest.go`, `logger.go`)
+- Go source files: lowercase, no separators (`config.go`, `natmsg.go`, `session.go`, `logger.go`)
 - Test files: `*_test.go` co-located with source (`config_test.go`, `tmux_test.go`)
 - Integration tests: separate file with `integration_` prefix (`integration_test.go`)
 - Entry points: always `main.go` under `cmd/<binary>/`
 
 **Functions:**
-- Exported: CamelCase (`Load`, `ResolveLogsDir`, `NewRunner`, `SessionExists`, `CheckVersion`)
+- Exported: CamelCase (`Load`, `NewRunner`, `SessionExists`, `CheckVersion`, `TouchFile`)
 - Unexported: camelCase (`interpolateEnvVars`, `findConfigFile`, `cmdUp`, `ensurePaneLogFiles`)
 - CLI commands: `cmd` prefix with CamelCase command name (`cmdInit`, `cmdUp`, `cmdDown`, `cmdAttach`)
-- Constructors: `New` + type name (`NewRunner`, `NewHost`, `NewHostWithStreams`)
+- Constructors: `New` + type name (`NewRunner`, `NewHost`, `NewHostWithStreams`, `New` for `browsersession.Session`)
 - Getters: `Get` prefix for retrieval (`GetLogsDir`, `GetSessionInfo`, `GetChromeNativeMessagingDir`)
 
 **Variables:**
 - camelCase for locals (`configPath`, `logsDir`, `sessionName`, `extensionID`)
 - Short names in tight scopes (`cfg`, `msg`, `err`, `cmd`, `dir`)
-- Receiver names: single letter matching type (`r` for `Runner`, `c` for `Config`, `l` for `Logger`, `h` for `Host`, `t` for `Timestamp`, `m` for `Message`)
+- Receiver names: single letter matching type (`r` for `Runner`, `c` for `Config`, `s` for `Session`, `h` for `Host`, `m` for `Message`)
 
 **Types:**
-- Exported structs: CamelCase nouns (`Config`, `Runner`, `Host`, `Logger`, `Message`, `Response`)
-- Info suffix for read-only data types (`SessionInfo`, `WindowInfo`, `PaneInfo`)
-- Config suffix for configuration types (`TmuxConfig`, `WindowConfig`, `PaneConfig`, `BrowserConfig`)
+- Exported structs: CamelCase nouns (`Config`, `Runner`, `Host`, `Logger`, `Message`, `Response`, `Session`)
+- Info suffix for read-only data types (`SessionInfo`, `WindowInfo`, `PaneInfo`, `HealthResult`)
+- Config suffix for configuration types (`TmuxConfig`, `WindowConfig`, `PaneConfig`, `BrowserConfig`, `SessionConfig`)
 - Function types: CamelCase (`Command` in `cmd/devlog/main.go`)
 
 **Constants:**
-- Unexported: camelCase (`usage`, `maxLabelLen`)
+- Unexported: camelCase (`usage`, `maxLabelLen`, `maxFindConfigDepth`)
 
 ## Code Style
 
@@ -55,26 +55,27 @@
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 	"regexp"
-	"sort"
 	"strings"
-	"time"
 
 	"gopkg.in/yaml.v3"
 )
 ```
 
-From `internal/logger/logger.go`:
+From `internal/tmux/tmux.go`:
 ```go
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
-	"sync"
+	"time"
 
-	"github.com/jellydn/devlog/internal/natmsg"
+	"github.com/jellydn/devlog/internal/config"
+	"github.com/jellydn/devlog/internal/fileutil"
+	"github.com/jellydn/devlog/internal/shellescape"
 )
 ```
 
@@ -94,8 +95,8 @@ if err != nil {
     return nil, fmt.Errorf("failed to parse config file: %w", err)
 }
 ```
-- Use `os.IsNotExist(err)` for graceful handling of missing files (`internal/config/config.go:167`)
-- Ignore errors explicitly with comment when appropriate (`cmd.Run() // Ignore errors - pane might not have a process` in `internal/tmux/tmux.go:200`)
+- Use `os.IsNotExist(err)` for graceful handling of missing files
+- Ignore errors explicitly with comment when appropriate (`cmd.Run() // Ignore errors - pane might not have a process`)
 
 ## Logging
 
@@ -105,31 +106,31 @@ if err != nil {
 - No logging framework; uses `fmt` package directly
 - Errors go to `os.Stderr` (`fmt.Fprintf(os.Stderr, "Error: %v\n", err)`)
 - Status/progress messages go to `os.Stdout` (`fmt.Printf("Starting devlog session '%s'...\n", ...)`)
-- Warning prefix for non-fatal issues (`fmt.Fprintf(os.Stderr, "Warning: ...")`)
+- Warning prefix for non-fatal issues (`fmt.Fprintf(os.Stderr, "Warning: ...\")`)
 - The `internal/logger` package is for browser log capture, not application logging
 
 ## Comments
 
 **When to Comment:**
 - All exported types and functions get `// TypeName ...` or `// FuncName ...` doc comments
-- Package-level doc comments on every package (`// Package natmsg implements ...`, `// Package logger handles ...`)
+- Package-level doc comments on every package (`// Package natmsg implements ...`, `// Package browsersession manages ...`)
 - Inline comments for non-obvious logic (`// Sanity check: messages shouldn't be larger than 10MB`)
 - Comments start with `// ` (space after slashes), capitalized first letter for doc comments
 - No commented-out code observed
 
 ## Function Design
 
-**Size:** Functions are generally 10–40 lines. Largest (`cmdUp`) is ~50 lines of sequential logic.
+**Size:** Functions are generally 10–40 lines. Largest is ~50 lines of sequential logic. Methods are broken down into focused private helpers when exceeding ~20 lines (e.g., `HealthCheck` delegates to `discoverHost`, `checkRegisteredBrowsers`, `repairAndCountPaths`).
 
 **Parameters:**
-- Accept interfaces/primitives over concrete types where possible
-- Configuration structs passed as `*Config` pointer
+- Accept interfaces over concrete types where possible (e.g., `ManifestOps`, `SessionChecker`)
+- Configuration structs passed as `*Config` pointer or by value (`SessionConfig`, `Policy`)
 - `io.Reader`/`io.Writer` for testable I/O (`NewHostWithStreams`)
 - String paths rather than file handles
 
 **Return Values:**
 - `(value, error)` tuple pattern consistently used
-- Pointer return for structs (`*Config`, `*Message`, `*SessionInfo`)
+- Pointer return for structs (`*Config`, `*Message`, `*SessionInfo`, `*HealthResult`)
 - `bool` for simple checks (`SessionExists`, `ShouldLog`)
 - Named return values not used
 
@@ -139,22 +140,28 @@ if err != nil {
 - Each package exports a focused API: types + constructor + methods
 - Internal packages under `internal/` prevent external use
 - CLI commands are unexported functions in `cmd/devlog/main.go`
+- Interface-based DI for testability (`ManifestOps`, `SessionChecker` in `internal/browsersession`)
 
 **Barrel Files:**
 - Not used. Each package has 1–3 files with clear responsibilities.
 
 **Package Structure:**
-- `internal/config/` — `config.go` (single file, types + loading + validation + cleanup)
-- `internal/tmux/` — `tmux.go` (runner + types), `integration_test.go` (build-tagged)
-- `internal/natmsg/` — `natmsg.go` (protocol), `manifest.go` (browser manifest management)
-- `internal/logger/` — `logger.go` (file-based log writer)
-- `cmd/devlog/` — `main.go` (CLI entry + all command implementations)
+- `internal/config/` — `config.go` (types + loading + validation)
+- `internal/tmux/` — `tmux.go` (runner + types + session management), `integration_test.go` (build-tagged)
+- `internal/natmsg/` — `natmsg.go` (wire protocol: Host, Message, read/write)
+- `internal/manifest/` — `manifest.go` (browser manifest install/update/repair), `validate_host_*.go` (OS-specific)
+- `internal/browsersession/` — `session.go` (Session, ManifestOps/SessionChecker interfaces, health check)
+- `internal/logrotate/` — `logrotate.go` (Policy, Result, Cleanup)
+- `internal/logger/` — `logger.go` (file-based log writer with level filtering)
+- `internal/fileutil/` — `touchfile.go` (shared TouchFile helper)
+- `internal/shellescape/` — `shellescape.go` (POSIX shell quoting)
+- `cmd/devlog/` — `main.go` (CLI entry + command dispatch) + `cmd_*.go` (one per command) + `browser_session_adapter.go` (DI adapters)
 - `cmd/devlog-host/` — `main.go` (native messaging host binary)
 
 **Dependencies:**
 - Minimal: only `gopkg.in/yaml.v3` as external dependency
 - Standard library preferred (`encoding/json`, `os/exec`, `path/filepath`)
-- No dependency injection framework; manual wiring via constructors
+- No dependency injection framework; manual wiring via constructors and adapters
 
 ---
-*Convention analysis: 2026-07-19*
+*Convention analysis: 2026-07-19 (regenerated)*

--- a/.planning/codebase/STRUCTURE.md
+++ b/.planning/codebase/STRUCTURE.md
@@ -1,13 +1,14 @@
 # Codebase Structure
 
-**Analysis Date:** 2026-07-19
+**Analysis Date:** 2026-07-19 (regenerated)
 
 ## Directory Layout
 ```text
 devlog/
 ├── cmd/
 │   ├── devlog/                  # CLI binary entry point
-│   │   ├── main.go              # Command dispatcher + usage (112 lines)
+│   │   ├── main.go              # Command dispatcher + usage
+│   │   ├── browser_session_adapter.go  # DI adapters for manifest/tmux → browsersession interfaces
 │   │   ├── cmd_attach.go        # `devlog attach`
 │   │   ├── cmd_down.go          # `devlog down`
 │   │   ├── cmd_healthcheck.go   # `devlog healthcheck`
@@ -17,37 +18,52 @@ devlog/
 │   │   ├── cmd_register.go      # `devlog register`
 │   │   ├── cmd_status.go        # `devlog status`
 │   │   ├── cmd_up.go            # `devlog up`
-│   │   ├── helpers.go           # Shared helpers: findConfigFile, browser host wrapper
-│   │   ├── browser_wrapper_test.go  # Tests for wrapper lifecycle helpers
+│   │   ├── helpers.go           # findConfigFile, ensureFileExists
 │   │   ├── healthcheck_test.go  # Tests for healthcheck command
-│   │   ├── helpers_test.go      # Tests for helpers (findConfigFile, scripts, etc.)
 │   │   ├── init_test.go         # Tests for init command
 │   │   └── status_test.go       # Tests for status command
 │   └── devlog-host/             # Native messaging host binary
-│       ├── main.go              # Stdin message loop → logger (100 lines)
+│       ├── main.go              # Stdin message loop → logger
 │       └── main_test.go         # Host loop tests with stream injection
 ├── internal/
 │   ├── config/                  # YAML config loading & validation
-│   │   ├── config.go            # Config types, Load(), Validate(), CleanupOldRuns()
-│   │   └── config_test.go       # 603 lines of table-driven tests
+│   │   ├── config.go            # Config types, Load(), Validate()
+│   │   └── config_test.go       # Table-driven tests
 │   ├── tmux/                    # Tmux session management
-│   │   ├── tmux.go              # Runner, session/window/pane operations
-│   │   ├── tmux_test.go         # Unit tests (289 lines)
-│   │   └── integration_test.go  # Integration tests requiring tmux (629 lines)
-│   ├── natmsg/                  # Native messaging protocol
+│   │   ├── tmux.go              # Runner, SessionConfig, session/window/pane operations
+│   │   ├── tmux_test.go         # Unit tests
+│   │   └── integration_test.go  # Integration tests requiring tmux (-tags=integration)
+│   ├── natmsg/                  # Native messaging wire protocol
 │   │   ├── natmsg.go            # Host, Message, wire protocol (length-prefixed JSON)
-│   │   ├── natmsg_test.go       # Protocol tests (367 lines)
-│   │   ├── manifest.go          # Browser manifest install/update for Chrome/Brave/Firefox
-│   │   └── manifest_test.go     # Manifest tests (227 lines)
-│   └── logger/                  # Log file writer with level filtering
-│       ├── logger.go            # Logger struct, formatted line output
-│       └── logger_test.go       # Logger tests (323 lines)
+│   │   └── natmsg_test.go       # Protocol tests
+│   ├── manifest/                # Browser manifest registration (extracted from natmsg)
+│   │   ├── manifest.go          # ChromeManifest, FirefoxManifest, install/update/repair
+│   │   ├── manifest_test.go     # Manifest tests
+│   │   ├── validate_host_unix.go    # ValidateHostPath (Unix, build-tagged)
+│   │   └── validate_host_windows.go # ValidateHostPath (Windows, build-tagged)
+│   ├── browsersession/          # Browser-log capture lifecycle (extracted from helpers.go)
+│   │   ├── session.go           # Session, ManifestOps/SessionChecker interfaces, HealthCheck
+│   │   ├── browsersession_test.go   # Round-trip, stale recovery, clobber tests
+│   │   └── helpers_test.go      # Sanitize, wrapper path, script generation tests
+│   ├── logrotate/               # Log directory cleanup (extracted from config)
+│   │   ├── logrotate.go         # Policy, Result, Cleanup
+│   │   └── logrotate_test.go    # Cleanup tests (max runs, retention days, dry run)
+│   ├── fileutil/                # Shared filesystem helpers
+│   │   ├── touchfile.go         # TouchFile (MkdirAll + OpenFile + Close)
+│   │   └── touchfile_test.go    # TouchFile tests
+│   ├── logger/                  # Log file writer with level filtering
+│   │   ├── logger.go            # Logger struct, formatted line output
+│   │   └── logger_test.go       # Logger tests
+│   └── shellescape/             # POSIX shell quoting
+│       ├── shellescape.go       # Quote function
+│       └── shellescape_test.go  # Shell quoting tests
 ├── browser-extension/           # Browser extension (Chrome + Firefox share root assets)
 │   ├── background.js            # Service worker: native messaging port, message routing
 │   ├── content_script.js        # Content script: bridges page_inject ↔ background
 │   ├── page_inject.js           # Page-context script: wraps console.* methods
 │   ├── popup.html               # Extension popup UI
 │   ├── popup.js                 # Popup logic
+│   ├── VERSION                  # Extension version (independent of Go binary version)
 │   ├── icons/                   # Extension icons (SVG + PNG)
 │   ├── chrome/                  # Chrome-specific manifest only; shared assets via symlinks
 │   │   ├── manifest.json        # Manifest V3
@@ -57,14 +73,21 @@ devlog/
 │   │   ├── popup.html → ../popup.html
 │   │   ├── popup.js → ../popup.js
 │   │   └── icons → ../icons
-│   └── firefox/                 # Firefox-specific manifest only; shared assets via symlinks
-│       ├── manifest.json        # Manifest V2
-│       ├── background.js → ../background.js
-│       ├── content_script.js → ../content_script.js
-│       ├── page_inject.js → ../page_inject.js
-│       ├── popup.html → ../popup.html
-│       ├── popup.js → ../popup.js
-│       └── icons → ../icons
+│   ├── firefox/                 # Firefox-specific manifest only; shared assets via symlinks
+│   │   ├── manifest.json        # Manifest V2
+│   │   ├── background.js → ../background.js
+│   │   ├── content_script.js → ../content_script.js
+│   │   ├── page_inject.js → ../page_inject.js
+│   │   ├── popup.html → ../popup.html
+│   │   ├── popup.js → ../popup.js
+│   │   └── icons → ../icons
+│   └── test/
+│       ├── vitest.config.js     # Extension test configuration
+│       ├── background.test.js   # Background service worker tests
+│       ├── content_script.test.js   # Content script tests
+│       ├── page_inject.test.js  # Page inject tests
+│       └── mocks/
+│           └── chrome.js        # Chrome API mocks
 ├── doc/                         # Documentation
 │   ├── adr/                     # Architecture Decision Records (6 ADRs)
 │   ├── PUBLICATION_CHECKLIST.md # Extension store publication guide
@@ -73,17 +96,17 @@ devlog/
 ├── scripts/                     # Build/packaging scripts
 │   ├── package-chrome.sh        # Chrome extension packaging
 │   ├── package-firefox.sh       # Firefox extension packaging
-│   ├── validate-screenshots.sh  # Screenshot dimension validator
-│   └── ralph/                   # Ralph autonomous agent config
+│   └── validate-screenshots.sh  # Screenshot dimension validator
 ├── dist/                        # Packaged extension ZIPs (build output)
 ├── go.mod                       # Go module: github.com/jellydn/devlog (Go 1.25+)
 ├── go.sum                       # Dependency checksums
 ├── justfile                     # Task runner (build, test, lint, dev)
 ├── devlog.yml.example           # Example configuration template
 ├── .goreleaser.yml              # GoReleaser config for binary releases
+├── .planning/                   # Planning and codebase analysis docs
+│   └── codebase/                # Auto-generated codemap analysis
 ├── .github/workflows/           # CI/CD (ci.yml, release.yml)
 ├── AGENTS.md                    # AI agent guidelines
-├── CLAUDE.md                    # Claude-specific instructions
 ├── README.md                    # Project documentation
 ├── PRIVACY.md                   # Privacy policy
 └── renovate.json                # Dependency update config
@@ -92,34 +115,59 @@ devlog/
 ## Directory Purposes
 
 **`cmd/devlog/`:**
-- Purpose: Main CLI application — one command per file plus shared helpers
-- Contains: Command dispatcher (`main.go`), one `cmd_*.go` per subcommand, helper functions in `helpers.go`
-- Key files: `main.go` (112 lines — dispatcher + usage), `helpers.go` (findConfigFile, browser host wrapper, script generation), `cmd_up.go`/`cmd_down.go`/`cmd_register.go` (primary user-facing commands)
+- Purpose: Main CLI application — one command per file plus shared helpers and DI adapters
+- Contains: Command dispatcher (`main.go`), one `cmd_*.go` per subcommand, `helpers.go` (findConfigFile, ensureFileExists), `browser_session_adapter.go` (adapters for ManifestOps/SessionChecker interfaces)
+- Key files: `main.go` (dispatcher + usage), `cmd_up.go`/`cmd_down.go`/`cmd_register.go` (primary user-facing commands)
 
 **`cmd/devlog-host/`:**
 - Purpose: Standalone binary launched by browsers via native messaging
 - Contains: Message read loop that bridges native messaging → logger
-- Key files: `main.go` (100 lines), `main_test.go` (host loop tests with stream injection)
+- Key files: `main.go`, `main_test.go` (host loop tests with stream injection)
 
 **`internal/config/`:**
-- Purpose: YAML configuration parsing, validation, env var interpolation, log retention cleanup
+- Purpose: YAML configuration parsing, validation, env var interpolation
 - Contains: Config structs with YAML tags, Load/Validate pipeline
-- Key files: `config.go` (230 lines), `config_test.go` (603 lines)
+- Key files: `config.go`, `config_test.go`
 
 **`internal/tmux/`:**
-- Purpose: Tmux subprocess management — session creation, window/pane setup, pipe-pane logging, session teardown
-- Contains: `Runner` type wrapping `os/exec` calls to `tmux` binary
-- Key files: `tmux.go` (367 lines), `integration_test.go` (629 lines, requires `-tags=integration`)
+- Purpose: Tmux subprocess management — session creation, window/pane setup, pipe-pane logging, session teardown. Owns log-dir resolution via SessionConfig.
+- Contains: `Runner` type wrapping `os/exec` calls to `tmux` binary; `SessionConfig` bundling session params
+- Key files: `tmux.go`, `integration_test.go` (requires `-tags=integration`)
 
 **`internal/natmsg/`:**
-- Purpose: Native Messaging wire protocol and browser manifest management
-- Contains: Length-prefixed JSON encoding/decoding, manifest JSON generation for Chrome/Brave/Firefox/Zen, binary discovery
-- Key files: `natmsg.go` (226 lines), `manifest.go` (314 lines)
+- Purpose: Native Messaging wire protocol (length-prefixed JSON over stdin/stdout)
+- Contains: `Host`, `Message`, `Response` types; `ReadMessage`, `WriteResponse`, `SendAck`
+- Key files: `natmsg.go`
+
+**`internal/manifest/`:**
+- Purpose: Browser manifest registration — install, update, repair for Chrome/Brave/Firefox/Zen
+- Contains: `ChromeManifest`, `FirefoxManifest` structs; install/update/repair functions; OS-specific `ValidateHostPath`
+- Key files: `manifest.go`, `validate_host_unix.go`, `validate_host_windows.go`
+
+**`internal/browsersession/`:**
+- Purpose: Browser-log capture lifecycle — wrapper creation, clobber protection, health checks
+- Contains: `Session` struct with `Start`/`Stop`/`HealthCheck`; `ManifestOps` and `SessionChecker` interfaces for DI; wrapper script generation
+- Key files: `session.go`, `browsersession_test.go`
+
+**`internal/logrotate/`:**
+- Purpose: Log directory retention cleanup for timestamped run mode
+- Contains: `Policy`, `Result`, `Cleanup` function
+- Key files: `logrotate.go`, `logrotate_test.go`
+
+**`internal/fileutil/`:**
+- Purpose: Shared filesystem utility functions
+- Contains: `TouchFile` — ensures a file exists
+- Key files: `touchfile.go`, `touchfile_test.go`
 
 **`internal/logger/`:**
 - Purpose: Formatted log writing with level-based filtering and thread-safe file access
 - Contains: `Logger` struct with mutex, append-only file writes
-- Key files: `logger.go` (131 lines)
+- Key files: `logger.go`
+
+**`internal/shellescape/`:**
+- Purpose: POSIX shell single-quote escaping for command injection prevention
+- Contains: `Quote` function
+- Key files: `shellescape.go`, `shellescape_test.go`
 
 **`browser-extension/`:**
 - Purpose: Browser extension for Chrome (Manifest V3) and Firefox (Manifest V2)
@@ -146,45 +194,53 @@ devlog/
 - `.github/workflows/release.yml`: Release pipeline
 
 **Core Logic:**
-- `internal/config/config.go`: Config loading, validation, env interpolation, retention cleanup
-- `internal/tmux/tmux.go`: Tmux session lifecycle management
+- `internal/config/config.go`: Config loading, validation, env interpolation
+- `internal/tmux/tmux.go`: Tmux session lifecycle management with SessionConfig
 - `internal/natmsg/natmsg.go`: Native Messaging wire protocol
-- `internal/natmsg/manifest.go`: Browser manifest installation
+- `internal/manifest/manifest.go`: Browser manifest installation
+- `internal/browsersession/session.go`: Browser-log wrapper lifecycle
+- `internal/logrotate/logrotate.go`: Log directory retention cleanup
 - `internal/logger/logger.go`: Log file writer with level filtering
+- `internal/fileutil/touchfile.go`: Shared file creation helper
+- `internal/shellescape/shellescape.go`: Shell argument escaping
 
 **Tests:**
 - `internal/config/config_test.go`: Config loading/validation tests
 - `internal/tmux/tmux_test.go`: Tmux unit tests
 - `internal/tmux/integration_test.go`: Tmux integration tests (build tag: `integration`)
 - `internal/natmsg/natmsg_test.go`: Protocol encoding/decoding tests
-- `internal/natmsg/manifest_test.go`: Manifest generation tests
+- `internal/manifest/manifest_test.go`: Manifest generation tests
+- `internal/browsersession/browsersession_test.go`: Session lifecycle, round-trip, stale recovery tests
+- `internal/browsersession/helpers_test.go`: Sanitize, path, script generation tests
+- `internal/logrotate/logrotate_test.go`: Cleanup policy tests
+- `internal/fileutil/touchfile_test.go`: TouchFile tests
 - `internal/logger/logger_test.go`: Logger formatting and filtering tests
 - `internal/shellescape/shellescape_test.go`: Shell quoting tests
 - `cmd/devlog/healthcheck_test.go`: Healthcheck command tests
 - `cmd/devlog/init_test.go`: Init command tests
 - `cmd/devlog/status_test.go`: Status command tests
-- `cmd/devlog/helpers_test.go`: `findConfigFile`, script generation, sanitization tests
-- `cmd/devlog/browser_wrapper_test.go`: Browser host wrapper lifecycle tests
 - `cmd/devlog-host/main_test.go`: Host message loop tests with stream injection
 - `browser-extension/test/`: Vitest tests for `background.js`, `content_script.js`, `page_inject.js`
 
 ## Naming Conventions
 
 **Files:**
-- Go source: `snake_case.go` (e.g., `config.go`, `natmsg.go`, `integration_test.go`)
+- Go source: lowercase, no separators (`config.go`, `session.go`, `tmux.go`)
 - Test files: `*_test.go` colocated with source
+- Build-tagged files: platform suffix (`validate_host_unix.go`, `validate_host_windows.go`)
 - JS files: `snake_case.js` (e.g., `content_script.js`, `page_inject.js`)
 - Scripts: `kebab-case.sh` (e.g., `package-chrome.sh`)
 
 **Directories:**
-- Go packages: lowercase single-word (e.g., `config`, `tmux`, `natmsg`, `logger`)
+- Go packages: lowercase single-word (e.g., `config`, `tmux`, `manifest`, `browsersession`)
 - Commands: kebab-case binary names (e.g., `devlog`, `devlog-host`)
 - Browser: `browser-extension/` with `chrome/` and `firefox/` subdirs
 
 **Go Naming:**
-- Exported: `CamelCase` (e.g., `NewRunner`, `CreateSession`, `SessionInfo`)
-- Unexported: `camelCase` (e.g., `cmdUp`, `sendCommandWithLogging`)
-- Test functions: `TestFunctionName_Description` (e.g., `TestLoad_ValidConfig`)
+- Exported: `CamelCase` (e.g., `NewRunner`, `CreateSession`, `SessionInfo`, `TouchFile`)
+- Unexported: `camelCase` (e.g., `cmdUp`, `sendCommandWithLogging`, `discoverHost`)
+- Test functions: `TestFunctionName_Description` (e.g., `TestLoad_ValidConfig`, `TestCleanup_MaxRuns`)
+- Interfaces: Noun or -er suffix (e.g., `ManifestOps`, `SessionChecker`)
 
 ## Where to Add New Code
 
@@ -197,6 +253,7 @@ devlog/
 - Create `internal/<package>/` directory
 - Follow existing patterns: exported types + constructor + methods
 - Add `*_test.go` colocated with source
+- Add package-level doc comment (`// Package <name> ...`)
 
 **New Browser Extension Feature:**
 - Modify shared root files in `browser-extension/` (used by both Chrome and Firefox via symlinks)
@@ -219,12 +276,13 @@ devlog/
 - Purpose: Architecture Decision Records documenting rationale for key design choices
 - Convention: Numbered `NNNN-title.md` format
 
-**`scripts/ralph/`:**
-- Purpose: Configuration for the Ralph autonomous agent (PRD, prompts, progress tracking)
+**`.planning/`:**
+- Purpose: Planning documents and auto-generated codebase analysis
+- Contains: `plan.md` (feature plans), `codebase/` (codemap analysis)
 
 **`.github/workflows/`:**
 - Purpose: GitHub Actions CI/CD pipelines
-- Contains: `ci.yml` (lint + test), `release.yml` (GoReleaser)
+- Contains: `ci.yml` (lint + test + multi-platform), `release.yml` (GoReleaser binary release)
 
 ---
-*Structure analysis: 2026-07-19*
+*Structure analysis: 2026-07-19 (regenerated)*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,10 @@ just init           # Copy devlog.yml.example -> devlog.yml
 - `cmd/devlog-host` — Native Messaging host binary the browser extension talks to via stdin. Has OS-specific files `validate_host_unix.go` / `validate_host_windows.go` (build-tagged).
 - `internal/config` — YAML config loading/validation.
 - `internal/tmux` — tmux session management; holds the only integration tests (`-tags=integration`).
-- `internal/natmsg` — native messaging protocol + manifest generation.
+- `internal/natmsg` — native messaging wire protocol (length-prefixed JSON over stdin/stdout).
+- `internal/manifest` — browser manifest registration for Chrome, Brave, and Firefox.
+- `internal/browsersession` — browser-log capture lifecycle (wrapper scripts, clobber protection, health checks).
+- `internal/logrotate` — log directory cleanup based on retention policy.
 - `internal/logger`, `internal/shellescape` — support packages.
 - `browser-extension/` — separate Node package (Chrome + Firefox). Own `npm ci` / `npm test`, not Go.
 

--- a/cmd/devlog/cmd_up.go
+++ b/cmd/devlog/cmd_up.go
@@ -27,7 +27,7 @@ func cmdUp(cfg *config.Config, args []string) error {
 		policy := logrotate.Policy{MaxRuns: cfg.MaxRuns, RetentionDays: cfg.RetentionDays}
 		if result, err := logrotate.Cleanup(cfg.LogsDir, policy, false); err != nil {
 			fmt.Fprintf(os.Stderr, "Warning: failed to cleanup old runs: %v\n", err)
-		} else if result != nil {
+		} else {
 			for _, dir := range result.Removed {
 				fmt.Printf("Removed old log directory: %s\n", dir)
 			}

--- a/cmd/devlog/helpers.go
+++ b/cmd/devlog/helpers.go
@@ -3,6 +3,8 @@ package main
 import (
 	"os"
 	"path/filepath"
+
+	"github.com/jellydn/devlog/internal/fileutil"
 )
 
 // maxFindConfigDepth limits how far findConfigFile walks up the directory tree.
@@ -35,12 +37,5 @@ func findConfigFile() string {
 }
 
 func ensureFileExists(path string) error {
-	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
-		return err
-	}
-	f, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0644)
-	if err != nil {
-		return err
-	}
-	return f.Close()
+	return fileutil.TouchFile(path)
 }

--- a/doc/STORE_SUBMISSION.md
+++ b/doc/STORE_SUBMISSION.md
@@ -291,27 +291,100 @@ Initial release:
 
 **License**: MIT
 
+## Automated Publishing (GitHub Actions)
+
+The `.github/workflows/release-extension.yml` workflow automates the full release pipeline: test → package → publish → GitHub Release.
+
+### How It Works
+
+1. **Trigger**: Push an `ext-v*` tag (e.g., `ext-v1.0.1`) or run manually via the Actions tab
+2. **Test**: Vitest extension tests must pass before packaging proceeds
+3. **Package**: Updates manifest versions from `browser-extension/VERSION`, runs packaging scripts, uploads ZIPs as artifacts
+4. **Publish**: Uploads to Chrome Web Store and Firefox Add-ons **in parallel** — partial success is allowed (one store failing doesn't block the other)
+5. **Release**: Creates a GitHub Release with both ZIPs attached, showing store publish status
+
+### Quick Start
+
+```bash
+# 1. Update the version file
+nano browser-extension/VERSION
+
+# 2. Commit and tag
+git add browser-extension/VERSION
+git commit -m "release: bump extension to v1.0.1"
+git tag ext-v1.0.1
+git push origin main ext-v1.0.1
+
+# 3. Monitor the workflow at:
+# https://github.com/jellydn/devlog/actions/workflows/release-extension.yml
+```
+
+### Required GitHub Secrets
+
+Set these in **Settings > Secrets and variables > Actions**:
+
+| Secret | Where to get it |
+|--------|----------------|
+| `CHROME_CLIENT_ID` | [Google Cloud Console](https://console.cloud.google.com/) → APIs & Services → Credentials → OAuth 2.0 Client ID |
+| `CHROME_CLIENT_SECRET` | Same as above — the client secret paired with the OAuth client ID |
+| `CHROME_REFRESH_TOKEN` | Generated via OAuth flow with the Chrome Web Store API scope. Use `chrome-webstore-upload-cli`'s refresh-token helper |
+| `FIREFOX_JWT_ISSUER` | [Firefox Add-on Developer Hub](https://addons.mozilla.org/developers/addon/api/key/) → API Credentials → JWT Issuer |
+| `FIREFOX_JWT_SECRET` | Same as above — JWT Secret |
+
+**Repository Variables** (Settings > Secrets and variables > Actions > Variables):
+
+| Variable | Value |
+|----------|-------|
+| `CHROME_EXTENSION_ID` | Your Chrome Web Store extension ID (from the developer dashboard URL) |
+
+### Obtaining Chrome Web Store Credentials
+
+1. Go to [Google Cloud Console](https://console.cloud.google.com/)
+2. Create a project (or use an existing one)
+3. Enable the **Chrome Web Store API**
+4. Go to **APIs & Services → OAuth consent screen** and configure it (External, add your email as test user)
+5. Go to **Credentials → Create Credentials → OAuth client ID**
+   - Application type: **Web application**
+   - Add `https://developers.google.com/oauthplayground` as an authorized redirect URI
+6. Use the generated client ID and secret as `CHROME_CLIENT_ID` and `CHROME_CLIENT_SECRET`
+7. Generate a refresh token:
+   - Go to [Google OAuth 2.0 Playground](https://developers.google.com/oauthplayground/)
+   - Click the gear icon (⚙️) → check **Use your own OAuth credentials** → enter your client ID and secret
+   - In the left panel, paste `https://www.googleapis.com/auth/chromewebstore` as the scope and click **Authorize APIs**
+   - Complete the OAuth flow, then click **Exchange authorization code for tokens**
+   - Copy the **Refresh token** and save it as `CHROME_REFRESH_TOKEN`
+
+### Obtaining Firefox Add-ons Credentials
+
+1. Go to [Firefox Add-on Developer Hub](https://addons.mozilla.org/developers/addon/api/key/)
+2. Click **Generate new credentials**
+3. Copy **JWT Issuer** → `FIREFOX_JWT_ISSUER`
+4. Copy **JWT Secret** → `FIREFOX_JWT_SECRET`
+
+### Manual Publishing (Fallback)
+
+If the automated workflow fails or you prefer manual publishing:
+
+```bash
+# Update version
+VERSION=$(cat browser-extension/VERSION)
+sed -i.bak "s/\"version\": \"[^\"]*\"/\"version\": \"$VERSION\"/" browser-extension/chrome/manifest.json && rm -f browser-extension/chrome/manifest.json.bak
+sed -i.bak "s/\"version\": \"[^\"]*\"/\"version\": \"$VERSION\"/" browser-extension/firefox/manifest.json && rm -f browser-extension/firefox/manifest.json.bak
+
+# Package
+./scripts/package-chrome.sh
+./scripts/package-firefox.sh
+
+# Upload manually to each store's developer dashboard
+```
+
 ## Version Management
 
-When releasing new versions:
+Extension versions are stored in `browser-extension/VERSION` and are **independent** from Go binary versions (which use `v*` git tags).
 
-1. Update version in both manifest files:
-   - `browser-extension/chrome/manifest.json`
-   - `browser-extension/firefox/manifest.json`
+The packaging scripts read this file and update `manifest.json` versions automatically.
 
-2. Package both extensions:
-   ```bash
-   ./scripts/package-chrome.sh
-   ./scripts/package-firefox.sh
-   ```
-
-3. Submit updated packages to both stores
-
-4. Create a GitHub release tag:
-   ```bash
-   git tag -a extension-v1.0.1 -m "Browser extension v1.0.1"
-   git push origin extension-v1.0.1
-   ```
+For manual releases, see [Manual Publishing](#manual-publishing-fallback) above.
 
 ## Maintenance Checklist
 

--- a/doc/adr/0007-package-extraction-refactor.md
+++ b/doc/adr/0007-package-extraction-refactor.md
@@ -1,0 +1,54 @@
+# 7. Package Extraction Refactor (Manifest, BrowserSession, Logrotate, Fileutil)
+
+Date: 2026-07-19
+
+## Status
+
+Accepted
+
+## Context
+
+After the initial implementation, several internal packages had grown to mix unrelated responsibilities:
+
+- `internal/natmsg` contained both the wire protocol (length-prefixed JSON over stdin/stdout) and browser manifest registration (install/update/repair for Chrome, Brave, Firefox). These are separate concerns — one is a protocol, the other is OS-level configuration management.
+- `internal/config` contained both configuration loading/validation and log directory cleanup logic (`CleanupOldRuns`). Cleanup is an operational concern, not a configuration concern.
+- `cmd/devlog/helpers.go` contained 12+ functions for browser-log wrapper lifecycle: script generation, wrapper path management, clobber protection, manifest repair, and health checks. These were orchestrated ad-hoc across `cmd_up.go`, `cmd_down.go`, and `cmd_healthcheck.go`.
+
+Additionally, the `EnsurePaneLogFiles` function in `internal/tmux` and `ensureFileExists` in `cmd/devlog/helpers.go` shared identical MkdirAll+OpenFile+Close logic, duplicated across package boundaries.
+
+Options considered:
+
+- **Keep as-is**: Accept the mixed responsibilities. Simpler in the short term but makes testing harder and creates unclear ownership.
+- **Extract into focused packages**: Split natmsg into `internal/natmsg` (protocol) and `internal/manifest` (browser registration). Extract cleanup from config into `internal/logrotate`. Extract wrapper lifecycle from helpers into `internal/browsersession`. Extract shared file utility into `internal/fileutil`.
+- **Merge everything into one package**: Opposite direction — put all logic into a single `internal/core` package. Would create a monolith with no clear boundaries.
+
+## Decision
+
+Extract into focused single-responsibility packages following these dependency rules:
+
+1. **`internal/manifest`** (extracted from `internal/natmsg`): Browser manifest registration only. Does not import natmsg. natmsg does not import manifest — no circular dependency.
+
+2. **`internal/browsersession`** (extracted from `cmd/devlog/helpers.go`): Browser-log capture lifecycle with a clean public API (`Session.Start`, `Session.Stop`, `Session.HealthCheck`). Uses interface-based dependency injection (`ManifestOps`, `SessionChecker`) for testability. Does not import `internal/config` or `cmd/devlog`.
+
+3. **`internal/logrotate`** (extracted from `internal/config`): Log directory cleanup based on retention policy (`Policy{MaxRuns, RetentionDays}`). `internal/config` drops the `sort` import. Later, after `tmux.Runner` absorbs `ResolveLogsDir`, config also drops the `time` import.
+
+4. **`internal/fileutil`** (new): Shared `TouchFile` helper eliminating duplication between `cmd/devlog/helpers.go` and `internal/tmux/tmux.go`.
+
+This follows the existing pattern established by `internal/shellescape` — small, focused utility packages with a single clear responsibility.
+
+## Consequences
+
+### Positive
+
+- **Clear ownership**: Each package has one reason to change (Single Responsibility)
+- **Testability**: `browsersession.Session` accepts interfaces, enabling fake injection in tests without real filesystem or tmux
+- **No circular dependencies**: manifest ↔ natmsg are independent; browsersession imports neither config nor cmd/devlog
+- **Reduced duplication**: `fileutil.TouchFile` used by both `cmd/devlog/helpers.go` and `internal/tmux/tmux.go`
+- **Smaller files**: `helpers.go` shrunk from ~255 lines to ~40 lines; `HealthCheck` method broken into three focused helpers
+- **config is cleaner**: `internal/config` no longer mixes retention logic with config types — it only handles loading, validation, and env interpolation
+
+### Negative
+
+- **More packages**: 4 new internal packages increase the directory count. Navigation overhead is minimal (each package is 1-3 files).
+- **Interface boilerplate**: `ManifestOps` and `SessionChecker` interfaces require thin adapter types in `cmd/devlog/browser_session_adapter.go`. This is standard Go DI and worth the testability gain. The final `ManifestOps` interface includes three browser-directory getter methods (`GetChromeNativeMessagingDir`, `GetBraveNativeMessagingDir`, `GetFirefoxNativeMessagingDirs`) not in the original design — these are needed by `HealthCheck` to discover registered browsers.
+- **Error message granularity trade-off**: `ensurePaneLogFiles` previously had three distinct error messages (directory creation, file creation, file close). After using `fileutil.TouchFile`, these collapse into one. The underlying OS error is still preserved via `%w` wrapping.

--- a/internal/browsersession/helpers_test.go
+++ b/internal/browsersession/helpers_test.go
@@ -80,4 +80,3 @@ func TestBatchQuote(t *testing.T) {
 		t.Errorf("batchQuote quotes = %q", batchQuote(`say "hi"`))
 	}
 }
-

--- a/internal/browsersession/session.go
+++ b/internal/browsersession/session.go
@@ -77,20 +77,29 @@ func (s *Session) Stop(sessionName string) {
 func (s *Session) HealthCheck() (*HealthResult, error) {
 	result := &HealthResult{}
 
+	s.discoverHost(result)
+	s.checkRegisteredBrowsers(result)
+	s.repairAndCountPaths(result)
+
+	return result, nil
+}
+
+// discoverHost finds the devlog-host binary and records whether it exists.
+func (s *Session) discoverHost(result *HealthResult) {
 	hostPath, err := s.manifest.FindDevlogHostBinary()
 	if err != nil {
 		result.HostFound = false
-	} else {
-		result.HostFound = true
-		result.HostPath = hostPath
+		return
 	}
+	result.HostFound = true
+	result.HostPath = hostPath
+}
 
+// checkRegisteredBrowsers checks which browsers have native messaging manifests
+// installed and records them in the result.
+func (s *Session) checkRegisteredBrowsers(result *HealthResult) {
 	chromeManifestPath := filepath.Join(s.manifest.GetChromeNativeMessagingDir(), "com.devlog.host.json")
 	braveManifestPath := filepath.Join(s.manifest.GetBraveNativeMessagingDir(), "com.devlog.host.json")
-	firefoxManifestPaths := []string{}
-	for _, dir := range s.manifest.GetFirefoxNativeMessagingDirs() {
-		firefoxManifestPaths = append(firefoxManifestPaths, filepath.Join(dir, "com.devlog.host.json"))
-	}
 
 	if _, err := os.Stat(chromeManifestPath); err == nil {
 		result.Registered = append(result.Registered, "Chrome")
@@ -98,22 +107,25 @@ func (s *Session) HealthCheck() (*HealthResult, error) {
 	if _, err := os.Stat(braveManifestPath); err == nil {
 		result.Registered = append(result.Registered, "Brave")
 	}
-	for _, path := range firefoxManifestPaths {
-		if _, err := os.Stat(path); err == nil {
+	for _, dir := range s.manifest.GetFirefoxNativeMessagingDirs() {
+		if _, err := os.Stat(filepath.Join(dir, "com.devlog.host.json")); err == nil {
 			result.Registered = append(result.Registered, "Firefox")
 			break
 		}
 	}
+}
 
+// repairAndCountPaths repairs stale manifest paths and counts total/stale manifest entries.
+func (s *Session) repairAndCountPaths(result *HealthResult) {
 	if result.HostFound {
-		if repaired, err := s.manifest.RepairStaleManifestPaths(hostPath); err == nil && repaired > 0 {
+		if repaired, err := s.manifest.RepairStaleManifestPaths(result.HostPath); err == nil && repaired > 0 {
 			result.RepairedPaths = repaired
 		}
 	}
 
 	paths, pathErr := s.manifest.ReadManifestPaths()
 	if pathErr != nil && len(paths) == 0 {
-		return result, nil
+		return
 	}
 	result.ManifestPaths = len(paths)
 	for _, p := range paths {
@@ -121,7 +133,6 @@ func (s *Session) HealthCheck() (*HealthResult, error) {
 			result.StalePaths++
 		}
 	}
-	return result, nil
 }
 
 func (s *Session) start(session, browserLogPath string, levels []string, hostPath string) error {

--- a/internal/e2e/cli_test.go
+++ b/internal/e2e/cli_test.go
@@ -1,0 +1,321 @@
+//go:build e2e
+
+// Package e2e contains end-to-end CLI smoke tests that exercise the built
+// devlog binary against a real tmux session. These tests require tmux
+// installed on PATH and are intended for CI or local pre-release verification.
+package e2e
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// binary is the path to the built devlog binary, set by TestMain.
+var binary string
+
+func TestMain(m *testing.M) {
+	// Build the CLI binary to a temp location.
+	tmp, err := os.MkdirTemp("", "devlog-e2e-*")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to create temp dir: %v\n", err)
+		os.Exit(1)
+	}
+
+	binary = filepath.Join(tmp, "devlog")
+	build := exec.Command("go", "build", "-o", binary, "../../cmd/devlog")
+	build.Stderr = os.Stderr
+	build.Stdout = os.Stdout
+	if err := build.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to build devlog binary: %v\n", err)
+		os.Exit(1)
+	}
+
+	code := m.Run()
+
+	os.RemoveAll(tmp)
+	os.Exit(code)
+}
+
+func skipIfNoTmux(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("tmux"); err != nil {
+		t.Skip("tmux not available in PATH")
+	}
+}
+
+// runDevlog executes the devlog binary with the given args from dir.
+func runDevlog(t *testing.T, dir string, args ...string) (stdout, stderr string, err error) {
+	t.Helper()
+	cmd := exec.Command(binary, args...)
+	cmd.Dir = dir
+	cmd.Env = os.Environ()
+	var outBuf, errBuf strings.Builder
+	cmd.Stdout = &outBuf
+	cmd.Stderr = &errBuf
+	err = cmd.Run()
+	return outBuf.String(), errBuf.String(), err
+}
+
+// sessionName returns a unique session name for test isolation.
+func sessionName() string {
+	return fmt.Sprintf("devlog-e2e-%d", time.Now().UnixNano())
+}
+
+// writeConfig writes a minimal devlog.yml for the given session and log dir.
+func writeConfig(t *testing.T, dir, session, logsDir string) {
+	t.Helper()
+
+	config := fmt.Sprintf(`version: "1.0"
+project: e2e-test
+logs_dir: %s
+run_mode: overwrite
+tmux:
+  session: %s
+  windows:
+    - name: test
+      panes:
+        - cmd: echo "hello-from-e2e"
+          log: test.log
+        - cmd: echo "pane-two"
+          log: pane2.log
+`, logsDir, session)
+
+	path := filepath.Join(dir, "devlog.yml")
+	if err := os.WriteFile(path, []byte(config), 0644); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+}
+
+// TestE2E_Lifecycle tests the full devlog lifecycle: up → status → down.
+func TestE2E_Lifecycle(t *testing.T) {
+	skipIfNoTmux(t)
+
+	session := sessionName()
+	tmpDir := t.TempDir()
+	logsDir := filepath.Join(tmpDir, "logs")
+
+	writeConfig(t, tmpDir, session, logsDir)
+
+	// 1. devlog up
+	stdout, stderr, err := runDevlog(t, tmpDir, "up")
+	if err != nil {
+		t.Fatalf("devlog up failed: %v\nstderr: %s\nstdout: %s", err, stderr, stdout)
+	}
+	if !strings.Contains(stdout, "Starting devlog session") {
+		t.Errorf("up output should mention starting session, got: %s", stdout)
+	}
+	if !strings.Contains(stdout, "Created tmux session") {
+		t.Errorf("up output should mention created session, got: %s", stdout)
+	}
+
+	// Ensure cleanup even if subsequent assertions fail.
+	defer func() {
+		runDevlog(t, tmpDir, "down")
+	}()
+
+	// 2. devlog status
+	stdout, stderr, err = runDevlog(t, tmpDir, "status")
+	if err != nil {
+		t.Fatalf("devlog status failed: %v\nstderr: %s\nstdout: %s", err, stderr, stdout)
+	}
+	if !strings.Contains(stdout, "Status: Running") {
+		t.Errorf("status should show Running, got: %s", stdout)
+	}
+
+	// 3. devlog down
+	stdout, stderr, err = runDevlog(t, tmpDir, "down")
+	if err != nil {
+		t.Fatalf("devlog down failed: %v\nstderr: %s\nstdout: %s", err, stderr, stdout)
+	}
+	if !strings.Contains(stdout, "Stopped tmux session") {
+		t.Errorf("down output should mention stopped session, got: %s", stdout)
+	}
+
+	// 4. devlog status after down
+	stdout, stderr, err = runDevlog(t, tmpDir, "status")
+	if err != nil {
+		t.Fatalf("devlog status after down failed: %v\nstderr: %s\nstdout: %s", err, stderr, stdout)
+	}
+	if !strings.Contains(stdout, "Not running") {
+		t.Errorf("status after down should show Not running, got: %s", stdout)
+	}
+
+	// 5. Verify log file was created
+	time.Sleep(100 * time.Millisecond)
+	logPath := filepath.Join(logsDir, "test.log")
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("failed to read log file: %v", err)
+	}
+	if !strings.Contains(string(data), "hello-from-e2e") {
+		t.Errorf("log should contain 'hello-from-e2e', got: %s", string(data))
+	}
+}
+
+// TestE2E_UpFailsWhenAlreadyRunning verifies that devlog up errors when a
+// session is already active.
+func TestE2E_UpFailsWhenAlreadyRunning(t *testing.T) {
+	skipIfNoTmux(t)
+
+	session := sessionName()
+	tmpDir := t.TempDir()
+	logsDir := filepath.Join(tmpDir, "logs")
+
+	writeConfig(t, tmpDir, session, logsDir)
+
+	// First up should succeed.
+	_, stderr, err := runDevlog(t, tmpDir, "up")
+	if err != nil {
+		t.Fatalf("first devlog up failed: %v\nstderr: %s", err, stderr)
+	}
+
+	defer func() {
+		runDevlog(t, tmpDir, "down")
+	}()
+
+	// Second up should fail.
+	_, stderr, err = runDevlog(t, tmpDir, "up")
+	if err == nil {
+		t.Error("second devlog up should have failed")
+	}
+	if !strings.Contains(stderr, "already exists") {
+		t.Errorf("up error should mention 'already exists', got: %s", stderr)
+	}
+}
+
+// TestE2E_Healthcheck verifies that devlog healthcheck detects tmux and
+// reports results.
+func TestE2E_Healthcheck(t *testing.T) {
+	skipIfNoTmux(t)
+
+	tmpDir := t.TempDir()
+
+	// Healthcheck may return an error when devlog-host is not installed
+	// (which is normal on CI). We only verify that tmux detection works.
+	stdout, _, _ := runDevlog(t, tmpDir, "healthcheck")
+
+	// Healthcheck should detect tmux.
+	if !strings.Contains(stdout, "tmux:") {
+		t.Errorf("healthcheck should check tmux, got: %s", stdout)
+	}
+}
+
+// TestE2E_Init verifies that devlog init creates a devlog.yml in the current
+// directory.
+func TestE2E_Init(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	stdout, stderr, err := runDevlog(t, tmpDir, "init")
+	if err != nil {
+		t.Fatalf("devlog init failed: %v\nstderr: %s\nstdout: %s", err, stderr, stdout)
+	}
+	if !strings.Contains(stdout, "Created devlog.yml") {
+		t.Errorf("init should mention Created devlog.yml, got: %s", stdout)
+	}
+
+	// Verify the file actually exists.
+	configPath := filepath.Join(tmpDir, "devlog.yml")
+	if _, err := os.Stat(configPath); os.IsNotExist(err) {
+		t.Error("devlog.yml was not created")
+	}
+
+	// Read it back and check it has content.
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("failed to read created config: %v", err)
+	}
+	if len(data) == 0 {
+		t.Error("created devlog.yml is empty")
+	}
+}
+
+// TestE2E_DownWithoutSession verifies that devlog down errors gracefully when
+// no session is running.
+func TestE2E_DownWithoutSession(t *testing.T) {
+	skipIfNoTmux(t)
+
+	session := sessionName()
+	tmpDir := t.TempDir()
+	logsDir := filepath.Join(tmpDir, "logs")
+
+	writeConfig(t, tmpDir, session, logsDir)
+
+	_, stderr, err := runDevlog(t, tmpDir, "down")
+	if err == nil {
+		t.Error("devlog down without session should fail")
+	}
+	if !strings.Contains(stderr, "does not exist") {
+		t.Errorf("down error should mention 'does not exist', got: %s", stderr)
+	}
+}
+
+// TestE2E_TimestampedMode verifies the timestamped run mode creates a
+// time-stamped log directory.
+func TestE2E_TimestampedMode(t *testing.T) {
+	skipIfNoTmux(t)
+
+	session := sessionName()
+	tmpDir := t.TempDir()
+	logsDir := filepath.Join(tmpDir, "logs")
+
+	config := fmt.Sprintf(`version: "1.0"
+project: e2e-test
+logs_dir: %s
+run_mode: timestamped
+tmux:
+  session: %s
+  windows:
+    - name: test
+      panes:
+        - cmd: echo "timestamped"
+          log: test.log
+`, logsDir, session)
+
+	configPath := filepath.Join(tmpDir, "devlog.yml")
+	if err := os.WriteFile(configPath, []byte(config), 0644); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+
+	stdout, stderr, err := runDevlog(t, tmpDir, "up")
+	if err != nil {
+		t.Fatalf("devlog up failed: %v\nstderr: %s\nstdout: %s", err, stderr, stdout)
+	}
+
+	defer func() {
+		runDevlog(t, tmpDir, "down")
+	}()
+
+	// Verify the logs dir has a timestamped subdirectory.
+	entries, err := os.ReadDir(logsDir)
+	if err != nil {
+		t.Fatalf("failed to read logs dir: %v", err)
+	}
+
+	found := false
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		// Timestamped dirs have format YYYYMMDD-HHMMSS (15 chars).
+		if len(entry.Name()) == 15 {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected a timestamped subdirectory in %s, got: %v", logsDir, entryNames(entries))
+	}
+}
+
+func entryNames(entries []os.DirEntry) []string {
+	names := make([]string, len(entries))
+	for i, e := range entries {
+		names[i] = e.Name()
+	}
+	return names
+}

--- a/internal/fileutil/touchfile.go
+++ b/internal/fileutil/touchfile.go
@@ -1,0 +1,20 @@
+// Package fileutil provides small filesystem utility helpers.
+package fileutil
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// TouchFile ensures the file at path exists by creating parent directories
+// and the file itself if needed. If the file already exists, it is not truncated.
+func TouchFile(path string) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return err
+	}
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0644)
+	if err != nil {
+		return err
+	}
+	return f.Close()
+}

--- a/internal/fileutil/touchfile.go
+++ b/internal/fileutil/touchfile.go
@@ -2,6 +2,7 @@
 package fileutil
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 )
@@ -10,11 +11,14 @@ import (
 // and the file itself if needed. If the file already exists, it is not truncated.
 func TouchFile(path string) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
-		return err
+		return fmt.Errorf("touch %q: %w", path, err)
 	}
 	f, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0644)
 	if err != nil {
-		return err
+		return fmt.Errorf("touch %q: %w", path, err)
 	}
-	return f.Close()
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("touch %q: %w", path, err)
+	}
+	return nil
 }

--- a/internal/fileutil/touchfile_test.go
+++ b/internal/fileutil/touchfile_test.go
@@ -3,6 +3,7 @@ package fileutil
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 )
 
@@ -65,7 +66,9 @@ func testDefaultPermissions(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if info.Mode().Perm() != 0644 {
+	// On Windows, os.Stat().Mode().Perm() does not reflect Unix permission bits
+	// (the OS uses ACLs instead), so skip the exact-mode assertion.
+	if runtime.GOOS != "windows" && info.Mode().Perm() != 0644 {
 		t.Errorf("mode = %o, want 0644", info.Mode().Perm())
 	}
 }

--- a/internal/fileutil/touchfile_test.go
+++ b/internal/fileutil/touchfile_test.go
@@ -1,0 +1,57 @@
+package fileutil
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestTouchFile_CreatesFileAndParents(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "a", "b", "test.log")
+
+	if err := TouchFile(path); err != nil {
+		t.Fatalf("TouchFile: %v", err)
+	}
+
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("file not created: %v", err)
+	}
+}
+
+func TestTouchFile_ExistingFileNotTruncated(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "existing.log")
+
+	if err := os.WriteFile(path, []byte("hello"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := TouchFile(path); err != nil {
+		t.Fatalf("TouchFile: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "hello" {
+		t.Errorf("data = %q, want %q", string(data), "hello")
+	}
+}
+
+func TestTouchFile_DefaultPermissions(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "perms.log")
+
+	if err := TouchFile(path); err != nil {
+		t.Fatalf("TouchFile: %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0644 {
+		t.Errorf("mode = %o, want 0644", info.Mode().Perm())
+	}
+}

--- a/internal/fileutil/touchfile_test.go
+++ b/internal/fileutil/touchfile_test.go
@@ -6,7 +6,21 @@ import (
 	"testing"
 )
 
-func TestTouchFile_CreatesFileAndParents(t *testing.T) {
+func TestTouchFile(t *testing.T) {
+	tests := []struct {
+		name string
+		fn   func(t *testing.T)
+	}{
+		{"CreatesFileAndParents", testCreatesFileAndParents},
+		{"ExistingFileNotTruncated", testExistingFileNotTruncated},
+		{"DefaultPermissions", testDefaultPermissions},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, tt.fn)
+	}
+}
+
+func testCreatesFileAndParents(t *testing.T) {
 	tmp := t.TempDir()
 	path := filepath.Join(tmp, "a", "b", "test.log")
 
@@ -19,7 +33,7 @@ func TestTouchFile_CreatesFileAndParents(t *testing.T) {
 	}
 }
 
-func TestTouchFile_ExistingFileNotTruncated(t *testing.T) {
+func testExistingFileNotTruncated(t *testing.T) {
 	tmp := t.TempDir()
 	path := filepath.Join(tmp, "existing.log")
 
@@ -39,7 +53,7 @@ func TestTouchFile_ExistingFileNotTruncated(t *testing.T) {
 	}
 }
 
-func TestTouchFile_DefaultPermissions(t *testing.T) {
+func testDefaultPermissions(t *testing.T) {
 	tmp := t.TempDir()
 	path := filepath.Join(tmp, "perms.log")
 

--- a/internal/logrotate/logrotate.go
+++ b/internal/logrotate/logrotate.go
@@ -1,3 +1,5 @@
+// Package logrotate handles cleanup of old timestamped log directories
+// based on configurable retention policies (max runs and retention days).
 package logrotate
 
 import (

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -199,29 +199,10 @@ func UpdateManifestPath(newPath string) error {
 
 	for _, dir := range dirs {
 		manifestPath := filepath.Join(dir, manifestFile)
-		data, err := os.ReadFile(manifestPath)
-		if err != nil {
+		if err := rewriteManifestPath(manifestPath, newPath); err != nil {
 			if !errors.Is(err, os.ErrNotExist) {
 				updateErrors = append(updateErrors, fmt.Sprintf("%s: %v", manifestPath, err))
 			}
-			continue
-		}
-
-		var raw map[string]interface{}
-		if err := json.Unmarshal(data, &raw); err != nil {
-			updateErrors = append(updateErrors, fmt.Sprintf("%s: invalid JSON: %v", manifestPath, err))
-			continue
-		}
-
-		raw["path"] = newPath
-		out, err := json.MarshalIndent(raw, "", "  ")
-		if err != nil {
-			updateErrors = append(updateErrors, fmt.Sprintf("%s: failed to marshal JSON: %v", manifestPath, err))
-			continue
-		}
-
-		if err := os.WriteFile(manifestPath, out, 0600); err != nil {
-			updateErrors = append(updateErrors, fmt.Sprintf("%s: failed to write file: %v", manifestPath, err))
 			continue
 		}
 		updated = true
@@ -351,6 +332,29 @@ func ReadManifestPaths() (map[string]string, error) {
 	return paths, nil
 }
 
+// rewriteManifestPath reads a manifest JSON from manifestPath, updates its
+// "path" field to newPath, and writes it back. ReadFile errors (including
+// os.ErrNotExist) are returned unwrapped so callers can use errors.Is.
+func rewriteManifestPath(manifestPath, newPath string) error {
+	data, err := os.ReadFile(manifestPath)
+	if err != nil {
+		return err
+	}
+	var raw map[string]interface{}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return fmt.Errorf("invalid JSON: %w", err)
+	}
+	raw["path"] = newPath
+	out, err := json.MarshalIndent(raw, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal: %w", err)
+	}
+	if err := os.WriteFile(manifestPath, out, 0600); err != nil {
+		return fmt.Errorf("failed to write: %w", err)
+	}
+	return nil
+}
+
 // RepairStaleManifestPaths rewrites any installed manifest whose path does not exist
 // back to hostPath (typically the real devlog-host binary).
 func RepairStaleManifestPaths(hostPath string) (repaired int, err error) {
@@ -358,26 +362,11 @@ func RepairStaleManifestPaths(hostPath string) (repaired int, err error) {
 		return 0, err
 	}
 	paths, readErr := ReadManifestPaths()
-	// Continue with any paths that were successfully read.
 	for manifestPath, current := range paths {
 		if _, statErr := os.Stat(current); statErr == nil {
 			continue
 		}
-		// Path missing — rewrite this single manifest.
-		data, err := os.ReadFile(manifestPath)
-		if err != nil {
-			continue
-		}
-		var raw map[string]interface{}
-		if err := json.Unmarshal(data, &raw); err != nil {
-			continue
-		}
-		raw["path"] = hostPath
-		out, err := json.MarshalIndent(raw, "", "  ")
-		if err != nil {
-			continue
-		}
-		if err := os.WriteFile(manifestPath, out, 0600); err != nil {
+		if err := rewriteManifestPath(manifestPath, hostPath); err != nil {
 			continue
 		}
 		repaired++

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -1,3 +1,6 @@
+// Package manifest manages browser native messaging host registration:
+// installing, updating, and repairing manifest JSON files for Chrome,
+// Brave, Firefox, and Zen browsers.
 package manifest
 
 import (

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/jellydn/devlog/internal/config"
+	"github.com/jellydn/devlog/internal/fileutil"
 	"github.com/jellydn/devlog/internal/shellescape"
 )
 
@@ -123,17 +124,8 @@ func ensurePaneLogFiles(logsDir string, windows []config.WindowConfig) error {
 			}
 			seen[logPath] = struct{}{}
 
-			logDir := filepath.Dir(logPath)
-			if err := os.MkdirAll(logDir, 0755); err != nil {
-				return fmt.Errorf("failed to create log directory '%s': %w", logDir, err)
-			}
-
-			f, err := os.OpenFile(logPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0644)
-			if err != nil {
+			if err := fileutil.TouchFile(logPath); err != nil {
 				return fmt.Errorf("failed to create log file '%s': %w", logPath, err)
-			}
-			if err := f.Close(); err != nil {
-				return fmt.Errorf("failed to close log file '%s': %w", logPath, err)
 			}
 		}
 	}

--- a/scripts/package-chrome.sh
+++ b/scripts/package-chrome.sh
@@ -19,7 +19,7 @@ VERSION=$(cat "$EXTENSION_DIR/VERSION")
 echo "Version: $VERSION"
 
 # Update manifest.json with version from VERSION file
-sed -i '' "s/\"version\": \"[^\"]*\"/\"version\": \"$VERSION\"/" "$CHROME_DIR/manifest.json"
+sed -i.bak "s/\"version\": \"[^\"]*\"/\"version\": \"$VERSION\"/" "$CHROME_DIR/manifest.json" && rm -f "$CHROME_DIR/manifest.json.bak"
 
 # Create temporary build directory
 BUILD_DIR=$(mktemp -d)

--- a/scripts/package-firefox.sh
+++ b/scripts/package-firefox.sh
@@ -19,7 +19,7 @@ VERSION=$(cat "$EXTENSION_DIR/VERSION")
 echo "Version: $VERSION"
 
 # Update manifest.json with version from VERSION file
-sed -i '' "s/\"version\": \"[^\"]*\"/\"version\": \"$VERSION\"/" "$FIREFOX_DIR/manifest.json"
+sed -i.bak "s/\"version\": \"[^\"]*\"/\"version\": \"$VERSION\"/" "$FIREFOX_DIR/manifest.json" && rm -f "$FIREFOX_DIR/manifest.json.bak"
 
 # Create temporary build directory
 BUILD_DIR=$(mktemp -d)


### PR DESCRIPTION
## What

Post-refactoring cleanup and improvements after extracting internal/manifest, internal/browsersession, and internal/logrotate (issues #66-#69).

## Changes

### Documentation
- **AGENTS.md**: Updated project layout with new packages (manifest, browsersession, logrotate, fileutil)
- **.planning/codebase/**: Regenerated ARCHITECTURE.md, STRUCTURE.md, CONVENTIONS.md with current package layout
- **doc/adr/0007**: New ADR documenting the package extraction architecture decisions
- **doc/STORE_SUBMISSION.md**: Added automated publishing section with secrets setup guide

### Refactoring
- **internal/browsersession/session.go**: Broke up ~70-line HealthCheck into discoverHost, checkRegisteredBrowsers, repairAndCountPaths
- **internal/fileutil/**: New shared TouchFile helper, eliminating MkdirAll+OpenFile+Close duplication between helpers.go and tmux.go
- **internal/manifest/manifest.go**: Extracted rewriteManifestPath helper, eliminating JSON read-update-write duplication in UpdateManifestPath and RepairStaleManifestPaths
- **cmd/devlog/cmd_up.go**: Cleaned up redundant nil check (static analysis fix)

### New workflow
- **.github/workflows/release-extension.yml**: Automated extension publishing pipeline — test → package → publish (Chrome + Firefox) → GitHub Release. Triggers on ext-v* tags and workflow_dispatch. Partial store failures allowed.

### Fixes
- **scripts/package-chrome.sh, package-firefox.sh**: Replaced macOS-specific sed -i '' with cross-platform sed -i.bak pattern for Linux CI compatibility
- **internal/browsersession/helpers_test.go**: gofmt fix
- **internal/fileutil/touchfile.go**: Wrapped all errors with %w; tests use t.Run() subtests

## Checklist

- [x] Tests added or updated (fileutil tests)
- [x] Documentation updated (AGENTS.md, ADR, STORE_SUBMISSION.md, codemap)
- [x] No breaking changes